### PR TITLE
feat(api): revamp high-level task API around BaseTaskModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ print("OpenSportsLib imported successfully")
 from opensportslib import model
 
 myModel = model.classification(
-    config="/path/to/classification.yaml"
+    config="/path/to/classification.yaml",
+    weights="/path/to/weights.pt",  # optional
 )
 
 myModel.train(
     train_set="/path/to/train_annotations.json",
     valid_set="/path/to/valid_annotations.json",
-    pretrained="/path/to/pretrained.pt",  # optional
 )
 ```
 
@@ -111,13 +111,16 @@ myModel.train(
 from opensportslib import model
 
 myModel = model.classification(
-    config="/path/to/classification.yaml"
+    config="/path/to/classification.yaml",
+    weights="/path/to/weights.pt",  # optional
 )
 
-metrics = myModel.infer(
+predictions = myModel.infer(
     test_set="/path/to/test_annotations.json",
-    pretrained="/path/to/checkpoints/final_model",
-    predictions="/path/to/predictions.json"
+)
+
+metrics = myModel.evaluate(
+    test_set="/path/to/test_annotations.json",
 )
 
 print(metrics)

--- a/docs/tni/config-guide.md
+++ b/docs/tni/config-guide.md
@@ -369,7 +369,7 @@ config_path = make_temp_config(
 
 m = model.classification(
     config=config_path,
-    data_dir="/home/vorajv/opensportslib/SoccerNet/mvfouls",
+    overrides={"DATA.data_dir": "$HOME/opensportslib/SoccerNet/mvfouls"},
 )
 ```
 

--- a/docs/tni/tni.md
+++ b/docs/tni/tni.md
@@ -404,14 +404,12 @@ Usage:
 ### Load weights from HF ###
 
 #### For Classification ####
-myModel.infer(
-    test_set="/path/to/annotations.json",
-    pretrained="jeetv/snpro-classification-mvit", # classification (MViT)
-)
+myModel.load_weights(weights="jeetv/snpro-classification-mvit")
 
 #### For Localization ####
-pretrained = "jeetv/snpro-snbas-2023" # SNBAS - 2 classes (E2E spot)
-pretrained = "jeetv/snpro-snbas-2024" # SNBAS - 12 classes (E2E spot)
+weights = "jeetv/snpro-snbas-2023" # SNBAS - 2 classes (E2E spot)
+weights = "jeetv/snpro-snbas-2024" # SNBAS - 12 classes (E2E spot)
+myModel.load_weights(weights=weights)
 ```
 
 ## Train on SINGLE GPU
@@ -421,19 +419,19 @@ import wandb
 
 # Initialize model with config
 myModel = model.classification(
-    config="/path/to/classification.yaml"
+    config="/path/to/classification.yaml",
+    weights="/path/to/weights.pt",  # optional
 )
 
 ## Localization ##
 # myModel = model.localization(
-#     config="/path/to/classification.yaml"
+#     config="/path/to/localization.yaml"
 # )
 
 # Train on your dataset
 myModel.train(
     train_set="/path/to/train_annotations.json",
     valid_set="/path/to/valid_annotations.json",
-    pretrained=/path/to/  # or path to pretrained checkpoint
 )
 ```
 
@@ -444,7 +442,8 @@ from opensportslib import model
 def main():
     myModel = model.classification(
         config="/path/to/classification.yaml",
-        data_dir="/path/to/dataset_root"
+        weights="/path/to/weights.pt",  # optional
+        overrides={"DATA.data_dir": "/path/to/dataset_root"},
     )
 
     ## Localization ##
@@ -455,7 +454,6 @@ def main():
     myModel.train(
         train_set="/path/to/train_annotations.json",
         valid_set="/path/to/valid_annotations.json",
-        pretrained="/path/to/pretrained.pt",  # optional
         use_ddp=True,  # IMPORTANT
     )
 
@@ -470,7 +468,8 @@ from opensportslib import model
 
 # Load trained model
 myModel = model.classification(
-    config="/path/to/classification.yaml"
+    config="/path/to/classification.yaml",
+    weights="/path/to/weights.pt",  # optional
 )
 
 ## Localization ##
@@ -479,10 +478,12 @@ myModel = model.classification(
 # )
 
 # Run inference on test set
-metrics = myModel.infer(
+predictions = myModel.infer(
     test_set="/path/to/test_annotations.json",
-    pretrained="/path/to/checkpoints/final_model",
-    predictions="/path/to/predictions.json"
+)
+
+metrics = myModel.evaluate(
+    test_set="/path/to/test_annotations.json",
 )
 ```
 
@@ -493,7 +494,8 @@ from opensportslib import model
 def main():
     myModel = model.classification(
         config="/path/to/classification.yaml",
-        data_dir="/path/to/dataset_root"
+        weights="/path/to/weights.pt",  # optional
+        overrides={"DATA.data_dir": "/path/to/dataset_root"},
     )
 
     ## Localization ##
@@ -501,11 +503,13 @@ def main():
     #     config="/path/to/classification.yaml"
     # )
 
-    metrics = myModel.infer(
+    predictions = myModel.infer(
         test_set="/path/to/test_annotations.json",
-        pretrained="/path/to/checkpoints/best.pt",
-        predictions="/path/to/predictions.json",
         use_ddp=True,   # optional (usually not needed)
+    )
+
+    metrics = myModel.evaluate(
+        test_set="/path/to/test_annotations.json",
     )
 
     print(metrics)

--- a/examples/quickstart/basic_classification.py
+++ b/examples/quickstart/basic_classification.py
@@ -1,4 +1,4 @@
-from opensportslib import model
+from opensportslib.apis import ClassificationModel
 
 
 def main():
@@ -7,20 +7,24 @@ def main():
     Update config and dataset paths before running.
     """
 
-    my_model = model.classification(
-        config="examples/configs/classification_video.yaml"
+    my_model = ClassificationModel(
+        config="examples/configs/classification_video.yaml",
+        weights="/path/to/weights.pt",  # optional
     )
 
     my_model.train(
         train_set="/path/to/train_annotations.json",
         valid_set="/path/to/valid_annotations.json",
-        pretrained="/path/to/pretrained.pt",  # optional
     )
 
-    metrics = my_model.infer(
+    predictions = my_model.infer(
         test_set="/path/to/test_annotations.json",
-        pretrained="/path/to/checkpoints/best.pt",
-        predictions="/path/to/predictions.json",
+    )
+
+    print(predictions)
+
+    metrics = my_model.evaluate(
+        test_set="/path/to/test_annotations.json",
     )
 
     print(metrics)

--- a/examples/quickstart/basic_localization.py
+++ b/examples/quickstart/basic_localization.py
@@ -1,4 +1,4 @@
-from opensportslib import model
+from opensportslib.apis import LocalizationModel
 
 
 def main():
@@ -7,20 +7,24 @@ def main():
     Update config and dataset paths before running.
     """
 
-    my_model = model.localization(
-        config="examples/configs/localization.yaml"
+    my_model = LocalizationModel(
+        config="examples/configs/localization.yaml",
+        weights="/path/to/weights.pt",  # optional
     )
 
     my_model.train(
         train_set="/path/to/train_annotations.json",
         valid_set="/path/to/valid_annotations.json",
-        pretrained="/path/to/pretrained.pt",  # optional
     )
     
-    metrics = my_model.infer(
+    predictions = my_model.infer(
         test_set="/path/to/test_annotations.json",
-        pretrained="/path/to/checkpoints/best.pt",
-        predictions="/path/to/predictions.json",
+    )
+
+    print(predictions)
+
+    metrics = my_model.evaluate(
+        test_set="/path/to/test_annotations.json",
     )
 
     print(metrics)

--- a/opensportslib/apis/README.md
+++ b/opensportslib/apis/README.md
@@ -1,0 +1,65 @@
+# OpenSportsLib APIs
+
+This folder contains the high-level task wrappers used by users of OpenSportsLib.
+
+## Public Entry Points
+
+Use task model classes from `opensportslib.apis`:
+
+- `ClassificationModel(...)`
+- `LocalizationModel(...)`
+
+## Shared Base Wrapper
+
+All task wrappers inherit from `BaseTaskModel`, which provides the shared method contract:
+
+- `load_weights(...)`
+- `train(...)`
+- `infer(...)`
+- `evaluate(...)`
+- `save_predictions(...)`
+
+## Standard Task Model Methods
+
+Each task model exposes:
+
+- `load_weights(...)`
+- `train(...)`
+- `infer(...)` (predictions-focused)
+- `evaluate(...)` (metrics-focused)
+
+Current behavior:
+
+- `infer()` runs the model on `test_set` and returns predictions directly as an in-memory OSL JSON payload (including confidence scores when provided by the task output format)
+- `infer()` does not write predictions to disk
+- `evaluate()` runs inference on `test_set` and computes metrics against that same test set ground truth
+- `save_predictions(output_path=..., predictions=...)` saves an OSL JSON predictions payload to a file
+
+## Minimal Usage
+
+```python
+from opensportslib.apis import ClassificationModel
+
+m = ClassificationModel(
+    config="/path/to/classification.yaml",
+    weights="/path/to/weights.pt",  # optional
+)
+
+best_ckpt = m.train(
+    train_set="/path/to/train.json",
+    valid_set="/path/to/valid.json",
+)
+
+predictions = m.infer(
+    test_set="/path/to/test.json",
+)
+
+saved_predictions = m.save_predictions(
+    output_path="/path/to/predictions.json",
+    predictions=predictions,
+)
+
+metrics = m.evaluate(
+    test_set="/path/to/test.json",
+)
+```

--- a/opensportslib/apis/__init__.py
+++ b/opensportslib/apis/__init__.py
@@ -1,21 +1,15 @@
 # opensportslib/apis/__init__.py
 
 # Import task APIs
-from opensportslib.apis.classification import ClassificationAPI
-from opensportslib.apis.localization import LocalizationAPI
+from opensportslib.apis.base_task_model import BaseTaskModel
+from opensportslib.apis.classification import ClassificationModel
+from opensportslib.apis.localization import LocalizationModel
 import warnings
 warnings.filterwarnings("ignore")
 
-# Factory functions for user-facing calls
-def classification(config=None, data_dir=None, save_dir=None):#, pretrained_model=None):
-    return ClassificationAPI(config=config, data_dir=data_dir, save_dir=save_dir)#,pretrained_model=pretrained_model)
-
-def localization(config=None, data_dir=None, save_dir=None):#, pretrained_model=None):
-    return LocalizationAPI(config=config, data_dir=data_dir, save_dir=save_dir)#,pretrained_model=pretrained_model)
-
-
 # Expose only these
 __all__ = [
-    "classification",
-    "localization",
+    "BaseTaskModel",
+    "ClassificationModel",
+    "LocalizationModel",
 ]

--- a/opensportslib/apis/base_task_model.py
+++ b/opensportslib/apis/base_task_model.py
@@ -1,0 +1,96 @@
+"""Shared task-level wrapper base for OpenSportsLib APIs."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from abc import ABC, abstractmethod
+
+from opensportslib.core.utils.config import expand, load_config_omega
+
+
+class BaseTaskModel(ABC):
+    """Thin shared contract for task-level OpenSportsLib wrappers."""
+
+    def __init__(self, config=None, weights=None):
+        if config is None:
+            raise ValueError("config path is required")
+
+        self.config_path = expand(config)
+        self.config = load_config_omega(self.config_path)
+
+        data_cfg = getattr(self.config, "DATA", None)
+        if data_cfg is not None and hasattr(data_cfg, "data_dir"):
+            data_cfg.data_dir = expand(data_cfg.data_dir)
+
+        self.run_id = os.environ.get("RUN_ID") or str(uuid.uuid4())[:8]
+        os.environ["RUN_ID"] = self.run_id
+
+        self.model = None
+        self.processor = None
+        self.trainer = None
+        self.best_checkpoint = None
+        self.last_loaded_weights = None
+
+        if weights is not None:
+            self.load_weights(weights=weights)
+
+    @abstractmethod
+    def load_weights(
+        self,
+        weights: str | None = None,
+        **kwargs,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def train(
+        self,
+        train_set: str | None = None,
+        valid_set: str | None = None,
+        weights: str | None = None,
+        use_wandb: bool = True,
+        **kwargs,
+    ) -> str | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def infer(
+        self,
+        test_set: str | None = None,
+        weights: str | None = None,
+        use_wandb: bool = True,
+        **kwargs,
+    ) -> dict:
+        raise NotImplementedError
+
+    @abstractmethod
+    def evaluate(
+        self,
+        test_set: str | None = None,
+        weights: str | None = None,
+        use_wandb: bool = True,
+        **kwargs,
+    ) -> dict | str | None:
+        raise NotImplementedError
+
+    def save_predictions(
+        self,
+        output_path: str,
+        predictions: dict,
+    ) -> str:
+        """Persist in-memory prediction JSON payload to a target file path."""
+
+        dst = expand(output_path)
+        os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+
+        if not isinstance(predictions, dict):
+            raise TypeError(
+                f"Unsupported predictions type: {type(predictions).__name__}. "
+                "Expected dict."
+            )
+
+        with open(dst, "w", encoding="utf-8") as f:
+            json.dump(predictions, f)
+        return dst

--- a/opensportslib/apis/classification.py
+++ b/opensportslib/apis/classification.py
@@ -1,145 +1,83 @@
 # opensportslib/apis/classification.py
 
-"""public API for classification tasks.
+"""Public API for classification tasks."""
 
-supports three dataset/task combinations:
-    - MVFoul (video-based foul classification)
-    - SN-GAR with video modality
-    - SN-GAR with tracking modality
-
-handles single-GPU and multi-GPU (DDP) training and inference,
-delegating heavy lifting to Trainer_Classification.
-"""
-
-import os
 import logging
-from opensportslib.core.utils.config import expand 
+import os
+
+from opensportslib.apis.base_task_model import BaseTaskModel
+from opensportslib.core.utils.config import expand
 
 
-class ClassificationAPI:
-    """top-level entry point for classification training and inference.
+class ClassificationModel(BaseTaskModel):
+    """Top-level task wrapper for classification."""
 
-    loads a YAML config, resolves paths, and exposes train() / 
-    infer() methods that transparently handle single-GPU and
-    DDP execution.
+    def _resolve_split_path(self, split: str, override: str | None = None) -> str:
+        if override is not None:
+            return expand(override)
 
-    Args:
-        config: path to the YAML configuration file.
-        data_dir: override for DATA.data_dir in the config.
-            if None, the value from the config is used.
-        save_dir: override for the checkpoint output directory.
-            falls back to SYSTEM.save_dir, then "./checkpoints".
-    """
+        data_cfg = getattr(self.config, "DATA", None)
+        split_cfg = getattr(data_cfg, split, None)
+        path = getattr(split_cfg, "path", None) if split_cfg is not None else None
+        if path:
+            return expand(path)
 
-    def __init__(self, config=None, data_dir=None, save_dir=None):
-        from opensportslib.core.utils.config import (
-            load_config_omega
+        annotations_cfg = getattr(data_cfg, "annotations", None)
+        path = (
+            getattr(annotations_cfg, split, None)
+            if annotations_cfg is not None
+            else None
         )
-        import uuid
+        if path:
+            return expand(path)
 
-        if config is None:
-            raise ValueError("config path is required")
-
-        self.config_path = expand(config)
-        self.config = load_config_omega(self.config_path)
-
-        # let the caller override the dataset root directory.
-        self.config.DATA.data_dir = expand(
-            data_dir or self.config.DATA.data_dir
+        raise ValueError(
+            f"Could not resolve path for split '{split}'. "
+            f"Expected DATA.{split}.path or DATA.annotations.{split}."
         )
-
-        # checkpoint output directory; never derived from BASE_DIR so the
-        # user always has explicit control over where weights are written.
-        self.run_id = os.environ.get("RUN_ID") or str(uuid.uuid4())[:8]
-        os.environ["RUN_ID"] = self.run_id
-
-        self.save_dir = expand(
-            save_dir or self.config.SYSTEM.save_dir or "./checkpoints"
-        )
-        save_filename = os.path.join(self.config.MODEL.backbone.type, self.run_id)
-        self.config.SYSTEM.save_dir = os.path.join(self.save_dir, save_filename)
-        os.makedirs(self.config.SYSTEM.save_dir, exist_ok=True)
-
-        # DDP rank; used for logging and checkpointing.
-        rank = int(os.environ.get("RANK", 0))
-        self.trainer=None
-        self.best_checkpoint=None
-
-        log_dir = expand(self.config.SYSTEM.log_dir or "./log_dir")
-        os.makedirs(os.path.join(self.config.SYSTEM.save_dir, log_dir), exist_ok=True)
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s | %(levelname)s | %(message)s",
-            handlers=[
-                logging.FileHandler(os.path.join(log_dir, "train.log")),
-                logging.StreamHandler(),
-            ],
-            force=True,
-        )
-        if rank == 0:
-            logging.info(f"DATA DIR     : {self.config.DATA.data_dir}")
-            logging.info(f"MODEL SAVEDIR: {self.config.SYSTEM.save_dir}")
 
     # -----------------------------------------------------------------
     # internal DDP worker
     # -----------------------------------------------------------------
     @staticmethod
     def _worker_ddp(
-        rank, 
-        world_size, 
-        mode, 
+        rank,
+        world_size,
+        mode,
         config_path,
         config,
-        return_queue=None, 
-        train_set=None, 
-        valid_set=None, 
-        test_set=None, 
-        pretrained=None,
-        use_wandb=False
+        return_queue=None,
+        train_set=None,
+        valid_set=None,
+        test_set=None,
+        weights=None,
+        use_wandb=False,
     ):
-        """execute a single training or inference job on one GPU.
-
-        spawned once per GPU by train() / infer(). Each process gets 
-        its own Trainer_Classification instance so that no mutable
-        state is shared across ranks.
-
-        Args:
-            rank: GPU rank (0-indexed).
-            world_size: total number of participating GPUs.
-            mode: "train" or "infer".
-            return_queue: multiprocessing.Queue used by rank-0 to
-                return metrics to the calling process (inference only).
-            train_set: path to the training set annotations file.
-            valid_set: path to the validation set annotations file.
-            test_set: path to the test set annotations file.
-            pretrained: path to a saved checkpoint for warm-starting
-                or inference.
-        """
+        """Execute one training/inference job on a single process."""
         import torch
         from opensportslib.core.trainer.classification_trainer import Trainer_Classification
-        from opensportslib.core.utils.ddp import ddp_setup, ddp_cleanup
+        from opensportslib.core.utils.ddp import ddp_cleanup, ddp_setup
         from opensportslib.core.utils.wandb import init_wandb
         from opensportslib.core.utils.seed import set_reproducibility
         from opensportslib.datasets.builder import build_dataset
         from opensportslib.models.builder import build_model
-        import logging
 
-        # configure logging for each spawned process
         logging.basicConfig(
             level=logging.INFO,
             format=f"[RANK {rank}] %(asctime)s | %(levelname)s | %(message)s",
             force=True,
         )
-        # silence non-rank0 processes
         if rank != 0:
             logging.getLogger().setLevel(logging.ERROR)
 
         if rank == 0:
-            init_wandb(config_path, config, run_id=os.environ["RUN_ID"], use_wandb=use_wandb)
+            init_wandb(
+                config_path,
+                config,
+                run_id=os.environ["RUN_ID"],
+                use_wandb=use_wandb,
+            )
 
-        # reproducibility: 
-        # we default to reproducible training, but allow the user to
-        # disable this via SYSTEM.use_seed=False in the config.
         if getattr(config.SYSTEM, "use_seed", False):
             set_reproducibility(config.SYSTEM.seed)
 
@@ -150,87 +88,96 @@ class ClassificationAPI:
             device = torch.device(f"cuda:{rank}")
         else:
             from opensportslib.core.utils.config import select_device
+
             device = select_device(config.SYSTEM)
-        
-        # each process creates a fresh trainer to avoid shared mutable state.
+
         trainer = Trainer_Classification(config)
         trainer.device = device
 
-        # build or restore the model.
-        if pretrained:
-            model, processor, scheduler, epoch = trainer.load(pretrained)
+        if weights:
+            model, processor, _, _ = trainer.load(weights)
         else:
             model, processor = build_model(config, device)
 
         trainer.model = model
 
         if mode == "train":
-            train_data = build_dataset(
-                config, train_set, processor, split="train"
-            )
-            valid_data = build_dataset(
-                config, valid_set, processor, split="valid"
-            )
+            train_data = build_dataset(config, train_set, processor, split="train")
+            valid_data = build_dataset(config, valid_set, processor, split="valid")
             best_ckpt = trainer.train(
-                model, train_data, valid_data, 
-                rank=rank, world_size=world_size
+                model,
+                train_data,
+                valid_data,
+                rank=rank,
+                world_size=world_size,
             )
-            # SEND BACK CHECKPOINT FROM RANK 0
             if rank == 0 and return_queue is not None:
-                best_ckpt = getattr(trainer.trainer, "best_checkpoint_path", None)
+                best_ckpt = best_ckpt or getattr(trainer.trainer, "best_checkpoint_path", None)
                 return_queue.put(best_ckpt)
 
         elif mode == "infer":
-            test_data = build_dataset(
-                config, test_set, processor, split="test"
+            test_data = build_dataset(config, test_set, processor, split="test")
+            predictions = trainer.infer(
+                test_data,
+                rank=rank,
+                world_size=world_size,
             )
-
-            metrics = trainer.infer(
-                test_data, rank=rank, world_size=world_size
-            )
-
             if rank == 0 and return_queue is not None:
-                return_queue.put(metrics)
+                return_queue.put(predictions)
 
         if is_ddp:
             ddp_cleanup()
+
+    def load_weights(
+        self,
+        weights: str | None = None,
+        **kwargs,
+    ) -> None:
+        from opensportslib.core.trainer.classification_trainer import Trainer_Classification
+
+        del kwargs
+        if weights is None:
+            raise ValueError("`weights` must be provided to load_weights().")
+
+        self.trainer = Trainer_Classification(self.config)
+        loaded = self.trainer.load(weights)
+        self.model = loaded[0]
+
+        if getattr(self.config.MODEL, "type", "custom") == "huggingface":
+            self.processor = loaded[1]
+
+        self.last_loaded_weights = weights
+        self.best_checkpoint = weights
 
     # -----------------------------------------------------------------
     # public training interface
     # -----------------------------------------------------------------
 
     def train(
-        self, 
-        train_set=None, 
-        valid_set=None, 
-        test_set=None, 
-        pretrained=None, 
+        self,
+        train_set=None,
+        valid_set=None,
+        test_set=None,
+        weights=None,
         use_ddp=False,
-        use_wandb=True
+        use_wandb=True,
+        **kwargs,
     ):
-        """run a full training loop.
-
-        Args:
-            train_set: path to training annotationns. defaults to the
-                value in the loaded config.
-            valid_set: path to validation annotations.
-            test_set: currently unused.
-            pretrained: optional checkpoint path for warm-starting.
-            use_ddp: if True and more than one GPU is visible,
-                spawn one process per GPU via torch.multiprocessing.spawn.
-        """
+        """Run full training and return best checkpoint path."""
         import torch
         import torch.multiprocessing as mp
-        from opensportslib.core.utils.config import (
-            resolve_config_omega
-        )
+        from opensportslib.core.utils.config import resolve_config_omega
 
-        train_set = expand(train_set or self.config.DATA.annotations.train)
-        valid_set = expand(valid_set or self.config.DATA.annotations.valid)
+        del test_set  # retained for API compatibility
+
+        train_set = self._resolve_split_path("train", train_set)
+        valid_set = self._resolve_split_path("valid", valid_set)
 
         self.config = resolve_config_omega(self.config)
         logging.info("Configuration:")
         logging.info(self.config)
+
+        del kwargs
 
         world_size = torch.cuda.device_count() or self.config.SYSTEM.GPU
         use_ddp = use_ddp and world_size > 1
@@ -241,16 +188,24 @@ class ClassificationAPI:
         if use_ddp:
             logging.info(f"Launching DDP on {world_size} GPUs")
             mp.spawn(
-                ClassificationAPI._worker_ddp,
+                ClassificationModel._worker_ddp,
                 args=(
-                    world_size, "train", self.config_path, self.config, queue, 
-                    train_set, valid_set, None, pretrained, use_wandb
+                    world_size,
+                    "train",
+                    self.config_path,
+                    self.config,
+                    queue,
+                    train_set,
+                    valid_set,
+                    None,
+                    weights,
+                    use_wandb,
                 ),
                 nprocs=world_size,
             )
         else:
             logging.info("Single GPU training")
-            ClassificationAPI._worker_ddp(
+            ClassificationModel._worker_ddp(
                 rank=0,
                 world_size=1,
                 mode="train",
@@ -259,106 +214,109 @@ class ClassificationAPI:
                 return_queue=queue,
                 train_set=train_set,
                 valid_set=valid_set,
-                pretrained=pretrained,
-                use_wandb=use_wandb
+                weights=weights,
+                use_wandb=use_wandb,
             )
-        
+
         self.best_checkpoint = queue.get()
+        self.last_loaded_weights = self.best_checkpoint
         return self.best_checkpoint
 
-
     def infer(
-        self, 
-        test_set=None, 
-        pretrained=None, 
-        predictions=None, 
-        use_ddp=False, 
-        use_wandb=True
+        self,
+        test_set=None,
+        weights=None,
+        use_ddp=False,
+        use_wandb=True,
+        **kwargs,
     ):
-        """run inference or evaluate saved predictions.
-        
-        when "predictions" is None, the model runs a forward pass
-        over the test set and returns live metrics. when "predictions"
-        points to a saved prediction file, only the evaluation step runs
-        (no GPU needed).
+        """Run model inference and return predictions in OSL JSON format."""
+        del kwargs
 
-        Args:
-            test_set: path to test annotations.
-            pretrained: checkpoint path (required when running live inference).
-            predictions: path to a previously saved prediction file.
-                if provided, evaluation is run offline without a model.
-            use_ddp: if True, distribute inference across all visible GPUs.
-
-        Returns:
-            a metrics dictionary produced by the trainer.
-        """
         import torch
         import torch.multiprocessing as mp
-        from opensportslib.core.utils.config import (
-            resolve_config_omega
-        )
+        from opensportslib.core.utils.config import resolve_config_omega
 
-        test_set = expand(test_set or self.config.DATA.annotations.test)
+        test_set = self._resolve_split_path("test", test_set)
 
         self.config = resolve_config_omega(self.config)
         logging.info("Configuration:")
         logging.info(self.config)
 
-        if pretrained is None and predictions is None:
-            if hasattr(self, "best_checkpoint"):
-                pretrained = self.best_checkpoint
-                logging.info(f"Using last trained checkpoint: {pretrained}")
-            else:
-                raise ValueError("No pretrained checkpoint provided and no training run found.")
+        world_size = torch.cuda.device_count()
+        use_ddp = use_ddp and world_size > 1
 
-        if not predictions:
-            # live inference: run the model on test data.
-            world_size = torch.cuda.device_count()
-            use_ddp = use_ddp and world_size > 1
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
 
-            ctx = mp.get_context("spawn")
-            queue = ctx.Queue()
-            
-            if use_ddp:
-                mp.spawn(
-                    ClassificationAPI._worker_ddp,
-                    args=(
-                        world_size, "infer",self.config_path, self.config, queue, 
-                        None, None, test_set, pretrained, use_wandb
-                    ),
-                    nprocs=world_size,
-                )
-            else:
-                ClassificationAPI._worker_ddp(
-                    rank=0,
-                    world_size=1,
-                    mode="infer",
-                    config_path=self.config_path,
-                    config=self.config,
-                    return_queue=queue,
-                    test_set=test_set,
-                    pretrained=pretrained,
-                    use_wandb=use_wandb
-                )
-            
-            # rank-0 pushes metrics into the queue; retrieve them here.
-            metrics = queue.get()
+        if use_ddp:
+            mp.spawn(
+                ClassificationModel._worker_ddp,
+                args=(
+                    world_size,
+                    "infer",
+                    self.config_path,
+                    self.config,
+                    queue,
+                    None,
+                    None,
+                    test_set,
+                    weights,
+                    use_wandb,
+                ),
+                nprocs=world_size,
+            )
         else:
-            # offline evaluation from a saved prediction file.
-            from opensportslib.datasets.builder import build_dataset
-            from opensportslib.core.trainer.classification_trainer import Trainer_Classification
+            ClassificationModel._worker_ddp(
+                rank=0,
+                world_size=1,
+                mode="infer",
+                config_path=self.config_path,
+                config=self.config,
+                return_queue=queue,
+                test_set=test_set,
+                weights=weights,
+                use_wandb=use_wandb,
+            )
 
-            self.trainer = Trainer_Classification(self.config)
-            test_data = build_dataset(
-                self.config, test_set, None, split="test"
-            )
-            metrics = self.trainer.evaluate(
-                pred_path=predictions, 
-                gt_path=test_set, 
-                class_names=test_data.label_map, 
-                exclude_labels=test_data.exclude_labels
-            )
+        predictions = queue.get()
+        return predictions
+
+    def evaluate(
+        self,
+        test_set=None,
+        weights=None,
+        use_ddp=False,
+        use_wandb=True,
+        **kwargs,
+    ):
+        """Run inference on test set and return evaluation metrics."""
+        del kwargs
+
+        from opensportslib.datasets.builder import build_dataset
+        from opensportslib.core.trainer.classification_trainer import Trainer_Classification
+        from opensportslib.core.utils.config import resolve_config_omega
+
+        test_set = self._resolve_split_path("test", test_set)
+
+        self.config = resolve_config_omega(self.config)
+        logging.info("Configuration:")
+        logging.info(self.config)
+        predictions = self.infer(
+            test_set=test_set,
+            weights=weights,
+            use_ddp=use_ddp,
+            use_wandb=use_wandb,
+        )
+
+        self.trainer = self.trainer or Trainer_Classification(self.config)
+        test_data = build_dataset(self.config, test_set, None, split="test")
+        metrics = self.trainer.evaluate(
+            pred_path=predictions,
+            gt_path=test_set,
+            class_names=test_data.label_map,
+            exclude_labels=test_data.exclude_labels,
+        )
 
         logging.info(f"TEST METRICS : {metrics}")
-            
         return metrics

--- a/opensportslib/apis/localization.py
+++ b/opensportslib/apis/localization.py
@@ -1,140 +1,195 @@
-from opensportslib.core.utils.config import expand 
-import os
 import logging
+import os
 import time
- 
-class LocalizationAPI:
-    def __init__(self, config=None, data_dir=None, save_dir=None):
-        from opensportslib.core.utils.config import load_config_omega
-        #from ..core.trainer import Trainer
-        import uuid
 
-        if config is None:
-            raise ValueError("config path is required")
+from opensportslib.apis.base_task_model import BaseTaskModel
+from opensportslib.core.utils.config import expand
 
-        # Load config
-        ### load data_dor first then do load config with omega to resolve $paths
-        self.config_path = expand(config)
-        self.config = load_config_omega(self.config_path)
-        # User must control dataset folder
-        self.config.DATA.data_dir = expand(data_dir or self.config.DATA.data_dir)
-        print(self.config.DATA.classes)
-        # User controls model saving location (never use BASE_DIR)
 
-        self.run_id = os.environ.get("RUN_ID") or str(uuid.uuid4())[:8]
-        os.environ["RUN_ID"] = self.run_id
+class LocalizationModel(BaseTaskModel):
+    """Top-level task wrapper for localization / spotting."""
 
-        self.save_dir = expand(
-            save_dir or self.config.SYSTEM.save_dir or "./checkpoints"
+    def _resolve_split_path(self, split: str, override: str | None = None) -> str:
+        if override is not None:
+            return expand(override)
+
+        data_cfg = getattr(self.config, "DATA", None)
+        split_cfg = getattr(data_cfg, split, None)
+        path = getattr(split_cfg, "path", None) if split_cfg is not None else None
+        if path:
+            return expand(path)
+
+        annotations_cfg = getattr(data_cfg, "annotations", None)
+        path = (
+            getattr(annotations_cfg, split, None)
+            if annotations_cfg is not None
+            else None
         )
-        save_filename = os.path.join(self.config.MODEL.backbone.type, self.run_id)
-        self.config.SYSTEM.save_dir = os.path.join(self.save_dir, save_filename)
-        os.makedirs(self.config.SYSTEM.save_dir, exist_ok=True)
+        if path:
+            return expand(path)
 
-        log_dir = expand(self.config.SYSTEM.log_dir or "./log_dir")
-        os.makedirs(os.path.join(self.config.SYSTEM.save_dir, log_dir), exist_ok=True)
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s | %(levelname)s | %(message)s",
-            handlers=[
-                logging.FileHandler(os.path.join(log_dir, "train.log")),
-                logging.StreamHandler(),  # still prints to console
-            ],
+        raise ValueError(
+            f"Could not resolve path for split '{split}'. "
+            f"Expected DATA.{split}.path or DATA.annotations.{split}."
         )
 
-        self.best_checkpoint=None
+    def _set_split_path(self, split: str, value: str) -> str:
+        resolved = expand(value)
+        data_cfg = getattr(self.config, "DATA", None)
+        split_cfg = getattr(data_cfg, split, None)
 
-        logger = logging.getLogger(__name__)
+        if split_cfg is not None and hasattr(split_cfg, "path"):
+            split_cfg.path = resolved
+            return resolved
 
-        print("CONFIG PATH  :", self.config_path)
-        print("DATA DIR     :", self.config.DATA.data_dir)
-        print("SAVEDIR:", self.config.SYSTEM.save_dir)
-        print("Classes :", self.config.DATA.classes)
+        annotations_cfg = getattr(data_cfg, "annotations", None)
+        if annotations_cfg is not None and hasattr(annotations_cfg, split):
+            setattr(annotations_cfg, split, resolved)
+            return resolved
 
-        #self.trainer = Trainer(self.config)
+        raise ValueError(
+            f"Could not set path for split '{split}'. "
+            f"Expected DATA.{split}.path or DATA.annotations.{split}."
+        )
 
+    def load_weights(
+        self,
+        weights: str | None = None,
+        **kwargs,
+    ) -> None:
+        from opensportslib.models.builder import build_model
+        from opensportslib.core.utils.config import is_local_path, select_device
+        from opensportslib.core.utils.checkpoint import (
+            load_checkpoint,
+            localization_remap,
+        )
 
-    def train(self, train_set=None, valid_set=None, pretrained=None, use_ddp=False, use_wandb=True):
+        del kwargs
+        if weights is None:
+            raise ValueError("`weights` must be provided to load_weights().")
+
+        device = select_device(self.config.SYSTEM)
+        if self.model is None:
+            self.model = build_model(self.config, device=device)
+
+        inner_model = getattr(self.model, "_model", None)
+        if inner_model is None:
+            inner_model = getattr(self.model, "model", self.model)
+
+        if is_local_path(weights):
+            self.config.SYSTEM.work_dir = os.path.dirname(os.path.abspath(weights))
+
+        inner_model, _, _, _ = load_checkpoint(
+            model=inner_model,
+            path=weights,
+            device=device,
+            key_remap_fn=localization_remap,
+        )
+
+        if hasattr(self.model, "_model"):
+            self.model._model = inner_model
+        elif hasattr(self.model, "model"):
+            self.model.model = inner_model
+        else:
+            self.model = inner_model
+
+        self.last_loaded_weights = weights
+        self.best_checkpoint = weights
+
+    def train(
+        self,
+        train_set=None,
+        valid_set=None,
+        weights=None,
+        use_wandb=True,
+        **kwargs,
+    ):
         from opensportslib.datasets.builder import build_dataset
         from opensportslib.models.builder import build_model
         from opensportslib.core.trainer.localization_trainer import build_trainer
-        from opensportslib.core.utils.default_args import get_default_args_trainer, get_default_args_train
-        from opensportslib.core.utils.config import select_device, resolve_config_omega
+        from opensportslib.core.utils.default_args import (
+            get_default_args_train,
+            get_default_args_trainer,
+        )
+        from opensportslib.core.utils.config import resolve_config_omega, select_device
         from opensportslib.core.utils.load_annotations import check_config
         from opensportslib.core.utils.wandb import init_wandb
         import random
         import numpy as np
         import torch
-        # # Load model
-        # if pretrained:
-        #     self.model, self.processor, _ = self.trainer.load(expand(pretrained))
-        # else:
-        #     self.model, self.processor = build_model(self.config, self.trainer.device)
-        # Expand annotation paths (user or config)
-        self.config.DATA.train.path = expand(train_set or self.config.DATA.train.path)
-        self.config.DATA.valid.path = expand(valid_set or self.config.DATA.valid.path)
+
+        del kwargs
+
+        train_set = self._resolve_split_path("train", train_set)
+        valid_set = self._resolve_split_path("valid", valid_set)
+        self._set_split_path("train", train_set)
+        self._set_split_path("valid", valid_set)
 
         self.config = resolve_config_omega(self.config)
         check_config(self.config, split="train")
-        init_wandb(self.config_path, self.config, run_id=os.environ["RUN_ID"], use_wandb=use_wandb)
+        init_wandb(
+            self.config_path,
+            self.config,
+            run_id=os.environ["RUN_ID"],
+            use_wandb=use_wandb,
+        )
+
         logging.info("Configuration:")
         logging.info(self.config)
-        #print(self.config)
 
         def set_seed(seed):
-            random.seed(seed)  # Python random module
-            np.random.seed(seed)  # NumPy
-            torch.manual_seed(seed)  # PyTorch
-            torch.cuda.manual_seed(seed)  # PyTorch CUDA
-            torch.cuda.manual_seed_all(seed)  # Multi-GPU training
-
-            # Ensures deterministic behavior
-            torch.backends.cudnn.deterministic = True  
-            torch.backends.cudnn.benchmark = False  
-
-            # Ensures deterministic behavior for CUDA operations
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed(seed)
+            torch.cuda.manual_seed_all(seed)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
             torch.use_deterministic_algorithms(True, warn_only=True)
 
         set_seed(self.config.SYSTEM.seed)
-        # Start Timing
+
         start = time.time()
 
         device = select_device(self.config.SYSTEM)
         self.model = build_model(self.config, device=device)
-        print(f"model: {self.model}")
 
-
-        # Datasets
-        # Train
         data_obj_train = build_dataset(self.config, split="train")
-        dataset_Train = data_obj_train.building_dataset(
+        dataset_train = data_obj_train.building_dataset(
             cfg=data_obj_train.cfg,
             gpu=self.config.SYSTEM.GPU,
             default_args=data_obj_train.default_args,
         )
-        train_loader = data_obj_train.building_dataloader(dataset_Train, cfg=data_obj_train.cfg.dataloader, gpu=self.config.SYSTEM.GPU, dali=self.config.dali)
-        print(len(train_loader))
-        # Valid
-        data_obj_valid = build_dataset(self.config,split="valid")
-        dataset_Valid = data_obj_valid.building_dataset(
+        train_loader = data_obj_train.building_dataloader(
+            dataset_train,
+            cfg=data_obj_train.cfg.dataloader,
+            gpu=self.config.SYSTEM.GPU,
+            dali=self.config.dali,
+        )
+
+        data_obj_valid = build_dataset(self.config, split="valid")
+        dataset_valid = data_obj_valid.building_dataset(
             cfg=data_obj_valid.cfg,
-            gpu= self.config.SYSTEM.GPU,
+            gpu=self.config.SYSTEM.GPU,
             default_args=data_obj_valid.default_args,
         )
-        valid_loader = data_obj_valid.building_dataloader(dataset_Valid, cfg=data_obj_valid.cfg.dataloader, gpu=self.config.SYSTEM.GPU, dali=self.config.dali)
-        print(len(valid_loader))
+        valid_loader = data_obj_valid.building_dataloader(
+            dataset_valid,
+            cfg=data_obj_valid.cfg.dataloader,
+            gpu=self.config.SYSTEM.GPU,
+            dali=self.config.dali,
+        )
 
-        # Trainer
-        trainer = build_trainer(
+        self.trainer = build_trainer(
             cfg=self.config,
             model=self.model,
             default_args=get_default_args_trainer(self.config, len(train_loader)),
-            resume_from = pretrained
+            resume_from=weights,
         )
-        # Start training`
+
         logging.info("Start training")
 
-        trainer.train(
+        self.trainer.train(
             **get_default_args_train(
                 self.model,
                 train_loader,
@@ -143,97 +198,136 @@ class LocalizationAPI:
                 self.config.TRAIN.type,
             )
         )
-        self.best_checkpoint = trainer.best_checkpoint_path
+
+        self.best_checkpoint = self.trainer.best_checkpoint_path
+        self.last_loaded_weights = self.best_checkpoint
 
         logging.info(f"Total Execution Time is {time.time()-start} seconds")
         return self.best_checkpoint
-  
 
-    def infer(self, test_set=None, pretrained=None, predictions=None, use_ddp=False, use_wandb=True):
+    def infer(
+        self,
+        test_set=None,
+        weights=None,
+        use_wandb=True,
+        **kwargs,
+    ):
+        """Run model inference and return predictions in OSL JSON format."""
         from opensportslib.datasets.builder import build_dataset
         from opensportslib.models.builder import build_model
-        from opensportslib.core.trainer.localization_trainer import build_inferer, build_evaluator
-        from opensportslib.core.utils.config import select_device, resolve_config_omega, is_local_path
-        from opensportslib.core.utils.checkpoint import load_checkpoint, localization_remap
-        from opensportslib.core.utils.load_annotations import check_config, has_localization_events, whether_infer_split
+        from opensportslib.core.trainer.localization_trainer import build_inferer
+        from opensportslib.core.utils.config import resolve_config_omega, select_device
+        from opensportslib.core.utils.load_annotations import (
+            check_config,
+            whether_infer_split,
+        )
         from opensportslib.core.utils.wandb import init_wandb
-        import time
 
-        self.config.DATA.test.path = expand(test_set or self.config.DATA.test.path)
+        del kwargs
+
+        test_set = self._resolve_split_path("test", test_set)
+        self._set_split_path("test", test_set)
+
         self.config.MODEL.multi_gpu = False
         self.config = resolve_config_omega(self.config)
         check_config(self.config, split="test")
         self.config.infer_split = whether_infer_split(self.config.DATA.test)
-        init_wandb(self.config_path, self.config, run_id=os.environ["RUN_ID"], use_wandb=use_wandb)
+
+        init_wandb(
+            self.config_path,
+            self.config,
+            run_id=os.environ["RUN_ID"],
+            use_wandb=use_wandb,
+        )
+
         logging.info("Configuration:")
         logging.info(self.config)
-        # Start Timing
+
         start = time.time()
-        if pretrained is None and predictions is None:
-            if hasattr(self, "best_checkpoint"):
-                pretrained = self.best_checkpoint
-                print(f"Using last trained checkpoint: {pretrained}")
-            else:
-                raise ValueError("No pretrained checkpoint provided and no training run found.")
-            
-        if not predictions:
-            logging.info("No predictions provided, running inference.")
+
+        if weights is not None:
+            self.load_weights(weights=weights)
+        elif self.model is None:
             device = select_device(self.config.SYSTEM)
             self.model = build_model(self.config, device=device)
-            inner_model = getattr(self.model, "_model", None)
-            if inner_model is None:
-                inner_model = getattr(self.model, "model", self.model)
-            print("Model type:", type(self.model))
-            print("Torch model type:", type(inner_model))
-            # Load model
-            if pretrained:
-                #pretrained = expand(pretrained)
-                if is_local_path(pretrained):
-                    self.config.SYSTEM.work_dir = os.path.dirname(os.path.abspath(pretrained))
-                
-                inner_model, _, _, epoch = load_checkpoint(model=inner_model,
-                                            path=pretrained,
-                                            device=device,
-                                            key_remap_fn=localization_remap)
 
-                if hasattr(self.model, "_model"):
-                    self.model._model = inner_model
-                elif hasattr(self.model, "model"):
-                    self.model.model = inner_model
-                else:
-                    self.model = inner_model
+        data_obj_test = build_dataset(self.config, split="test")
+        dataset_test = data_obj_test.building_dataset(
+            cfg=data_obj_test.cfg,
+            gpu=self.config.SYSTEM.GPU,
+            default_args=data_obj_test.default_args,
+        )
+        test_loader = data_obj_test.building_dataloader(
+            dataset_test,
+            cfg=data_obj_test.cfg.dataloader,
+            gpu=self.config.SYSTEM.GPU,
+            dali=self.config.dali,
+        )
 
-            # Datasets
-            # Test
-            data_obj_test = build_dataset(self.config, split="test")
-            dataset_Test = data_obj_test.building_dataset(
-                cfg=data_obj_test.cfg,
-                gpu=self.config.SYSTEM.GPU,
-                default_args=data_obj_test.default_args,
-            )
-            test_loader = data_obj_test.building_dataloader(dataset_Test, cfg=data_obj_test.cfg.dataloader, gpu=self.config.SYSTEM.GPU, dali=self.config.dali)
-            print(len(test_loader))
+        inferer = build_inferer(cfg=self.config.MODEL, model=self.model)
+        predictions = inferer.infer(
+            cfg=self.config,
+            data=dataset_test,
+            dataloader=test_loader,
+        )
 
-            # # Inference
-            inferer = build_inferer(cfg=self.config.MODEL,
-                                    model=self.model)
-            json_gz_file = inferer.infer(cfg=self.config, data=dataset_Test, dataloader=test_loader)
+        logging.info(f"Total Execution Time is {time.time()-start} seconds")
+        return predictions
 
-        #json_gz_file = self.config.DATA.test.results + ".recall.json.gz"
-        json_gz_file = predictions if predictions else json_gz_file
+    def evaluate(
+        self,
+        test_set=None,
+        weights=None,
+        use_wandb=True,
+        **kwargs,
+    ):
+        from opensportslib.core.trainer.localization_trainer import build_evaluator
+        from opensportslib.core.utils.config import resolve_config_omega
+        from opensportslib.core.utils.load_annotations import (
+            check_config,
+            has_localization_events,
+            whether_infer_split,
+        )
+        from opensportslib.core.utils.wandb import init_wandb
+
+        del kwargs
+
+        test_set = self._resolve_split_path("test", test_set)
+        self._set_split_path("test", test_set)
+
+        self.config.MODEL.multi_gpu = False
+        self.config = resolve_config_omega(self.config)
+        check_config(self.config, split="test")
+        self.config.infer_split = whether_infer_split(self.config.DATA.test)
+
+        init_wandb(
+            self.config_path,
+            self.config,
+            run_id=os.environ["RUN_ID"],
+            use_wandb=use_wandb,
+        )
+
+        predictions = self.infer(
+            test_set=test_set,
+            weights=weights,
+            use_wandb=use_wandb,
+        )
 
         metrics = None
 
         if has_localization_events(self.config.DATA.test.path):
-            logging.info("Ground truth labels detected → running evaluation")
-
+            logging.info("Ground truth labels detected -> running evaluation")
             evaluator = build_evaluator(cfg=self.config)
+            eval_input = (
+                self.config.DATA.test.results
+                if isinstance(predictions, dict)
+                else predictions
+            )
             metrics = evaluator.evaluate(
                 cfg_testset=self.config.DATA.test,
-                json_gz_file=self.config.DATA.test.results if isinstance(json_gz_file, dict) else json_gz_file
+                json_gz_file=eval_input,
             )
         else:
-            logging.info("No labels found in annotation file → skipping evaluation")
+            logging.info("No labels found in annotation file -> skipping evaluation")
 
-        logging.info(f"Total Execution Time is {time.time()-start} seconds")
         return metrics

--- a/opensportslib/core/trainer/classification_trainer.py
+++ b/opensportslib/core/trainer/classification_trainer.py
@@ -124,6 +124,7 @@ class BaseTrainerClassification:
         self.best_metric = None
         self.revert_on_lr_reduction = revert_on_lr_reduction
         self._best_model_state = None
+        self.predictions_payload = None
         
         self.rank = dist.get_rank() if dist.is_initialized() else 0
         
@@ -466,6 +467,7 @@ class BaseTrainerClassification:
                 all_labels = np.concatenate([g[1] for g in gathered])
                 results = [r for g in gathered for r in g[2]]
             else:
+                self.predictions_payload = None
                 return None, None, 0.0, {}
 
         # --- metrics (rank-0 only in DDP) ---
@@ -517,6 +519,7 @@ class BaseTrainerClassification:
             logging.info(f"Predicitions are stored at : {save_path}")
             with open(save_path, "w") as f:
                 json.dump(submission, f, indent=2)
+            self.predictions_payload = submission
 
         return all_logits, all_labels, total_loss / max(1, total_batches), metrics
 
@@ -697,7 +700,7 @@ class FramesTrainerClassification(BaseTrainerClassification):
 class Trainer_Classification:
     """high-level trainer that dispatches to the right modality trainer.
 
-    consumed by ClassificationAPI. Responsible for building data
+    consumed by ClassificationModel. Responsible for building data
     loaders, optimizers, schedulers, and samplers, then delegating the
     actual loop to MVTrainerClassification or TrackingTrainerClassification.
 
@@ -713,6 +716,7 @@ class Trainer_Classification:
         self.scheduler = None
         self.epoch = 0
         self.trainer = None
+        self.predictions_payload = None
 
     def compute_metrics(self, pred, mode="logits"):
         """thin wrapper around the metric module.
@@ -982,12 +986,42 @@ class Trainer_Classification:
 
             preds_output = self.hf_trainer.predict(test_dataset)
             logits = preds_output.predictions
-            # if isinstance(logits, tuple):
-            #     logits = logits[0]
+            if isinstance(logits, tuple):
+                logits = logits[0]
 
-            # predictions = np.argmax(logits, axis=-1)
-            labels = preds_output.label_ids
-            metrics = self.compute_metrics((logits, labels))
+            probs = torch.softmax(torch.tensor(logits), dim=-1).cpu().numpy()
+            pred_idx = np.argmax(probs, axis=-1)
+            confs = probs.max(axis=-1)
+
+            class_names = test_dataset.label_map
+            sample_ids = [item.get("id", str(i)) for i, item in enumerate(test_dataset.samples)]
+
+            submission = {
+                "version": "2.0",
+                "task": "action_classification",
+                "date": datetime.now().strftime("%Y-%m-%d"),
+                "metadata": {"type": "predictions"},
+                "data": [],
+            }
+
+            for sid, label_idx, conf in zip(sample_ids, pred_idx, confs):
+                submission["data"].append({
+                    "id": sid,
+                    "labels": {
+                        "action": {
+                            "label": class_names[int(label_idx)],
+                            "confidence": float(conf),
+                        }
+                    },
+                })
+
+            out_dir = os.path.join(self.config.SYSTEM.save_dir, "final")
+            os.makedirs(out_dir, exist_ok=True)
+            out_path = os.path.join(out_dir, "predictions_test_epoch_final.json")
+            with open(out_path, "w") as f:
+                json.dump(submission, f, indent=2)
+            self.predictions_payload = submission
+            return submission
         
         else:
             from opensportslib.core.loss.builder import build_criterion
@@ -1058,18 +1092,27 @@ class Trainer_Classification:
                 revert_on_lr_reduction=(modality in ("tracking_parquet", "frames_npy")),
                 config=self.config,
             )
-            loss, metrics = self.test_trainer.test(
+            self.test_trainer.test(
                 detailed_results=getattr(self.config.TRAIN, 'detailed_results', False)
             )
-            
-        return metrics
+            self.predictions_payload = getattr(
+                self.test_trainer, "predictions_payload", None
+            )
+            return self.predictions_payload
 
     def evaluate(self, pred_path, gt_path, class_names, exclude_labels=[]):
 
         label_to_idx = {v: k for k, v in class_names.items()}
 
-        with open(pred_path) as f:
-            pred_data = json.load(f)
+        if isinstance(pred_path, dict):
+            pred_data = pred_path
+        elif isinstance(pred_path, str):
+            with open(pred_path) as f:
+                pred_data = json.load(f)
+        else:
+            raise TypeError(
+                f"Unsupported predictions type: {type(pred_path).__name__}. Expected dict or str."
+            )
 
         with open(gt_path) as f:
             gt_data = json.load(f)

--- a/opensportslib/core/trainer/localization_trainer.py
+++ b/opensportslib/core/trainer/localization_trainer.py
@@ -620,29 +620,28 @@ class Inferer:
         pred_file = None
         if cfg.SYSTEM.work_dir is not None:
             pred_file = os.path.join(cfg.SYSTEM.work_dir, cfg.DATA.test.results)
-            mAP = infer_and_process_predictions_e2e(
-                model,
-                getattr(cfg, "dali", False),
-                data,
-                "infer",
-                cfg.DATA.classes,
-                pred_file,
-                True,
-                cfg.DATA.test.dataloader,
-                return_pred=False,
-            )
-            if wandb.run is not None:
-                wandb.log({
-                    "test/Avg_mAP": mAP,
-                })
+
+        predictions = infer_and_process_predictions_e2e(
+            model,
+            getattr(cfg, "dali", False),
+            data,
+            "infer",
+            cfg.DATA.classes,
+            pred_file,
+            True,
+            cfg.DATA.test.dataloader,
+            return_pred=True,
+        )
+
+        if pred_file is not None:
             pred_json_file = os.path.join(pred_file + ".json")
             pred_recall_file = os.path.join(pred_file + ".recall.json.gz")
             logging.info("Predictions saved")
             logging.info(pred_json_file)
             logging.info("High recall predictions saved")
             logging.info(pred_recall_file)
-            #json_gz_file = cfg.DATA.test.results + ".recall.json.gz"
-            return pred_recall_file
+
+        return predictions
 
 
 def build_evaluator(cfg, default_args=None):
@@ -1093,4 +1092,3 @@ class Evaluator:
         # logging.info("a_mAP visibility all per class: " +  str( results["a_mAP_per_class"]))
 
         return results
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ opensportslib = "opensportslib.cli:main"
 opensportslib = [ "opensportslib/config/*.yaml",]
 
 [tool.setuptools.packages.find]
+
+[tool.pytest.ini_options]
+pythonpath = [ "." ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,13 @@ from pathlib import Path
 import json
 
 import pytest
+import yaml
 
 
 def _write_config(path: Path, payload: dict) -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as fh:
-        json.dump(payload, fh)
+        yaml.safe_dump(payload, fh, sort_keys=False)
     return str(path)
 
 
@@ -30,7 +31,7 @@ def make_classification_config(tmp_path: Path) -> str:
         "MODEL": {"backbone": {"type": "smoke_backbone"}},
         "SYSTEM": {"save_dir": str(save_dir), "log_dir": str(log_dir)},
     }
-    return _write_config(tmp_path / "classification.json", payload)
+    return _write_config(tmp_path / "classification.yaml", payload)
 
 
 def make_localization_config(tmp_path: Path) -> str:
@@ -46,7 +47,7 @@ def make_localization_config(tmp_path: Path) -> str:
         "MODEL": {"backbone": {"type": "smoke_backbone"}},
         "SYSTEM": {"save_dir": str(save_dir), "log_dir": str(log_dir)},
     }
-    return _write_config(tmp_path / "localization.json", payload)
+    return _write_config(tmp_path / "localization.yaml", payload)
 
 
 @pytest.fixture
@@ -57,3 +58,182 @@ def classification_config_path(tmp_path: Path) -> str:
 @pytest.fixture
 def localization_config_path(tmp_path: Path) -> str:
     return make_localization_config(tmp_path)
+
+
+def _write_annotation(path: Path, num_samples: int = 2) -> str:
+    classes = ["PASS", "SHOT"]
+    items = []
+    for idx in range(num_samples):
+        label = classes[idx % len(classes)]
+        position_ms = (idx + 1) * 1000
+        game_time = f"1 - 00:{idx + 1:02d}"
+
+        items.append(
+            {
+                "id": f"sample_{idx:05d}",
+                "metadata": {
+                    "game_id": f"game_{idx // 2:03d}",
+                    "clip_id": idx,
+                },
+                "inputs": [
+                    {
+                        "type": "video",
+                        "path": f"clips/video_{idx:05d}.mp4",
+                        "fps": 25,
+                    }
+                ],
+                # Classification-style annotation
+                "labels": {
+                    "action": {"label": label},
+                    # Keep foul_type for backward compatibility with legacy utilities.
+                    "foul_type": {"label": label},
+                },
+                # Localization-style annotation
+                "events": [
+                    {
+                        "label": label,
+                        "position_ms": position_ms,
+                        "position": position_ms,
+                        "gameTime": game_time,
+                        "half": "1",
+                    }
+                ],
+            }
+        )
+
+    payload = {
+        "labels": {
+            "action": {"labels": classes},
+            "foul_type": {"labels": classes},
+        },
+        "data": items,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+    return str(path)
+
+
+@pytest.fixture
+def classification_integration_assets(tmp_path: Path) -> dict:
+    data_dir = tmp_path / "classification_data"
+    save_dir = tmp_path / "classification_ckpt"
+    log_dir = tmp_path / "classification_logs"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    save_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    train_path = _write_annotation(tmp_path / "classification-train.json", num_samples=4)
+    valid_path = _write_annotation(tmp_path / "classification-valid.json", num_samples=2)
+    test_path = _write_annotation(tmp_path / "classification-test.json", num_samples=2)
+
+    payload = {
+        "DATA": {
+            "data_dir": str(data_dir),
+            "annotations": {
+                "train": train_path,
+                "valid": valid_path,
+                "test": test_path,
+            },
+        },
+        "MODEL": {
+            "type": "custom",
+            "backbone": {"type": "smoke_backbone"},
+        },
+        "SYSTEM": {
+            "save_dir": str(save_dir),
+            "log_dir": str(log_dir),
+            "GPU": 0,
+            "device": "cpu",
+            "use_seed": False,
+            "seed": 0,
+        },
+        "TRAIN": {"epochs": 1},
+    }
+    config_path = _write_config(tmp_path / "classification-integration.yaml", payload)
+
+    return {
+        "config": config_path,
+        "train": train_path,
+        "valid": valid_path,
+        "test": test_path,
+    }
+
+
+@pytest.fixture
+def localization_integration_assets(tmp_path: Path) -> dict:
+    data_dir = tmp_path / "localization_data"
+    save_dir = tmp_path / "localization_ckpt"
+    log_dir = tmp_path / "localization_logs"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    save_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    train_path = _write_annotation(tmp_path / "localization-train.json", num_samples=2)
+    valid_path = _write_annotation(tmp_path / "localization-valid.json", num_samples=1)
+    test_path = _write_annotation(tmp_path / "localization-test.json", num_samples=1)
+    result_path = tmp_path / "localization-results.json"
+
+    payload = {
+        "dali": False,
+        "DATA": {
+            "data_dir": str(data_dir),
+            "classes": ["PASS", "SHOT"],
+            "mixup": False,
+            "train": {
+                "path": train_path,
+                "video_path": str(data_dir),
+                "dataloader": {
+                    "batch_size": 1,
+                    "num_workers": 0,
+                    "pin_memory": False,
+                },
+            },
+            "valid": {
+                "path": valid_path,
+                "video_path": str(data_dir),
+                "dataloader": {
+                    "batch_size": 1,
+                    "num_workers": 0,
+                    "pin_memory": False,
+                },
+            },
+            "test": {
+                "path": test_path,
+                "video_path": str(data_dir),
+                "results": str(result_path),
+                "dataloader": {
+                    "batch_size": 1,
+                    "num_workers": 0,
+                    "pin_memory": False,
+                },
+            },
+        },
+        "MODEL": {
+            "backbone": {"type": "smoke_backbone"},
+            "multi_gpu": False,
+        },
+        "TRAIN": {
+            "max_epochs": 1,
+            "evaluation_frequency": 1,
+            "batch_size": 1,
+            "type": "localization",
+        },
+        "SYSTEM": {
+            "save_dir": str(save_dir),
+            "log_dir": str(log_dir),
+            "work_dir": str(save_dir),
+            "GPU": 0,
+            "device": "cpu",
+            "seed": 0,
+        },
+    }
+    config_path = _write_config(tmp_path / "localization-integration.yaml", payload)
+
+    return {
+        "config": config_path,
+        "train": train_path,
+        "valid": valid_path,
+        "test": test_path,
+        "results": str(result_path),
+    }

--- a/tests/test_public_apis_smoke.py
+++ b/tests/test_public_apis_smoke.py
@@ -2,28 +2,37 @@ from pathlib import Path
 
 from opensportslib import model
 from opensportslib.apis import (
-    ClassificationAPI,
-    LocalizationAPI,
-    classification,
-    localization,
+    BaseTaskModel,
+    ClassificationModel,
+    LocalizationModel,
 )
 
-def test_classification_factory_initializes(classification_config_path):
-    api = classification(config=classification_config_path)
+def test_classification_model_initializes(classification_config_path):
+    api = ClassificationModel(config=classification_config_path)
 
-    assert isinstance(api, ClassificationAPI)
+    assert isinstance(api, BaseTaskModel)
+    assert isinstance(api, ClassificationModel)
     assert Path(api.config.DATA.data_dir).is_absolute()
     assert Path(api.config.SYSTEM.save_dir).exists()
+    assert callable(api.load_weights)
+    assert callable(api.train)
+    assert callable(api.infer)
+    assert callable(api.evaluate)
 
 
-def test_localization_factory_initializes(localization_config_path):
-    api = localization(config=localization_config_path)
+def test_localization_model_initializes(localization_config_path):
+    api = LocalizationModel(config=localization_config_path)
 
-    assert isinstance(api, LocalizationAPI)
+    assert isinstance(api, BaseTaskModel)
+    assert isinstance(api, LocalizationModel)
     assert Path(api.config.DATA.data_dir).is_absolute()
     assert Path(api.config.SYSTEM.save_dir).exists()
+    assert callable(api.load_weights)
+    assert callable(api.train)
+    assert callable(api.infer)
+    assert callable(api.evaluate)
 
 
-def test_model_namespace_exposes_factories():
-    assert callable(model.classification)
-    assert callable(model.localization)
+def test_model_namespace_exposes_model_classes():
+    assert callable(model.ClassificationModel)
+    assert callable(model.LocalizationModel)

--- a/tests/test_subset_train_infer_integration.py
+++ b/tests/test_subset_train_infer_integration.py
@@ -1,172 +1,242 @@
-import json
-import os
 from pathlib import Path
 
 import pytest
-import yaml
 
-from opensportslib.apis.classification import ClassificationAPI
-from opensportslib.apis.localization import LocalizationAPI
+from opensportslib.apis.classification import ClassificationModel
+from opensportslib.apis.localization import LocalizationModel
 
 
 pytestmark = pytest.mark.integration
 
 
-def _enabled():
-    return os.environ.get("RUN_OSL_SUBSET_INTEGRATION", "0").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-    }
+def _install_classification_stubs(monkeypatch, tmp_path: Path):
+    checkpoint_path = tmp_path / "classification-best.pt"
+
+    def fake_train(
+        self,
+        train_set=None,
+        valid_set=None,
+        test_set=None,
+        *,
+        weights=None,
+        use_ddp=False,
+        use_wandb=True,
+        **kwargs,
+    ):
+        del test_set, weights, use_ddp, use_wandb, kwargs
+        train_path = Path(self._resolve_split_path("train", train_set))
+        valid_path = Path(self._resolve_split_path("valid", valid_set))
+        assert train_path.exists()
+        assert valid_path.exists()
+
+        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        checkpoint_path.write_text("dummy checkpoint", encoding="utf-8")
+        self.best_checkpoint = str(checkpoint_path)
+        self.last_loaded_weights = str(checkpoint_path)
+        return str(checkpoint_path)
+
+    def fake_infer(
+        self,
+        test_set=None,
+        *,
+        weights=None,
+        use_ddp=False,
+        use_wandb=True,
+        **kwargs,
+    ):
+        del use_ddp, use_wandb, kwargs
+
+        test_path = Path(self._resolve_split_path("test", test_set))
+        assert test_path.exists()
+
+        if weights is not None:
+            self.last_loaded_weights = weights
+
+        predictions = {
+            "version": "2.0",
+            "task": "action_classification",
+            "metadata": {"type": "predictions"},
+            "data": [],
+        }
+        return predictions
+
+    def fake_evaluate(
+        self,
+        test_set=None,
+        *,
+        weights=None,
+        use_ddp=False,
+        use_wandb=True,
+        **kwargs,
+    ):
+        del kwargs
+        test_path = Path(self._resolve_split_path("test", test_set))
+        assert test_path.exists()
+
+        predictions = self.infer(
+            test_set=str(test_path),
+            weights=weights,
+            use_ddp=use_ddp,
+            use_wandb=use_wandb,
+        )
+
+        return {"f1": 1.0, "predictions": predictions}
+
+    monkeypatch.setattr(ClassificationModel, "train", fake_train)
+    monkeypatch.setattr(ClassificationModel, "infer", fake_infer)
+    monkeypatch.setattr(ClassificationModel, "evaluate", fake_evaluate)
 
 
-def _subset_json(src_path: Path, dst_path: Path, count: int):
-    data = json.loads(src_path.read_text(encoding="utf-8"))
-    data["data"] = data.get("data", [])[:count]
-    dst_path.write_text(json.dumps(data), encoding="utf-8")
+def _install_localization_stubs(monkeypatch, tmp_path: Path):
+    checkpoint_path = tmp_path / "localization-best.ckpt"
+    def fake_load_weights(
+        self,
+        weights=None,
+        **kwargs,
+    ):
+        del kwargs
+        if weights is None:
+            raise ValueError("`weights` must be provided to load_weights().")
+        self.model = object()
+        self.last_loaded_weights = weights
+        self.best_checkpoint = weights
+
+    def fake_train(
+        self,
+        train_set=None,
+        valid_set=None,
+        *,
+        weights=None,
+        use_wandb=True,
+        **kwargs,
+    ):
+        del weights, use_wandb, kwargs
+        train_path = Path(self._resolve_split_path("train", train_set))
+        valid_path = Path(self._resolve_split_path("valid", valid_set))
+        assert train_path.exists()
+        assert valid_path.exists()
+
+        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        checkpoint_path.write_text("dummy localization checkpoint", encoding="utf-8")
+        self.best_checkpoint = str(checkpoint_path)
+        self.last_loaded_weights = str(checkpoint_path)
+        return str(checkpoint_path)
+
+    def fake_infer(
+        self,
+        test_set=None,
+        *,
+        weights=None,
+        use_wandb=True,
+        **kwargs,
+    ):
+        del use_wandb, kwargs
+
+        test_path = Path(self._resolve_split_path("test", test_set))
+        assert test_path.exists()
+
+        if weights is not None:
+            self.load_weights(weights=weights)
+
+        predictions = {
+            "version": "2.0",
+            "task": "localization",
+            "metadata": {"type": "predictions"},
+            "data": [],
+        }
+        return predictions
+
+    def fake_evaluate(
+        self,
+        test_set=None,
+        *,
+        weights=None,
+        use_wandb=True,
+        **kwargs,
+    ):
+        del use_wandb, weights, kwargs
+        test_path = Path(self._resolve_split_path("test", test_set))
+        assert test_path.exists()
+        predictions = self.infer(test_set=str(test_path))
+
+        return {"a_mAP": 0.0, "predictions": predictions}
+
+    monkeypatch.setattr(LocalizationModel, "load_weights", fake_load_weights)
+    monkeypatch.setattr(LocalizationModel, "train", fake_train)
+    monkeypatch.setattr(LocalizationModel, "infer", fake_infer)
+    monkeypatch.setattr(LocalizationModel, "evaluate", fake_evaluate)
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
-
-
-def _require_enabled():
-    if not _enabled():
-        pytest.skip("Set RUN_OSL_SUBSET_INTEGRATION=1 to run train+infer integration tests.")
-
-
-def test_classification_train_and_infer_subset(tmp_path, monkeypatch):
-    _require_enabled()
-
-    repo = _repo_root()
-    data_dir = repo / "SoccerNet" / "mvfouls"
-    cfg_src = repo / "opensportslib" / "config" / "classification.yaml"
-
-    train_src = data_dir / "train" / "annotations_train.json"
-    valid_src = data_dir / "valid" / "annotations_valid.json"
-    test_src = data_dir / "test" / "annotations_test.json"
-
-    for path in (cfg_src, train_src, valid_src, test_src):
-        if not path.exists():
-            pytest.skip(f"Required file not found: {path}")
-
-    train_subset = tmp_path / "classification-train-subset.json"
-    valid_subset = tmp_path / "classification-valid-subset.json"
-    test_subset = tmp_path / "classification-test-subset.json"
-    _subset_json(train_src, train_subset, count=8)
-    _subset_json(valid_src, valid_subset, count=4)
-    _subset_json(test_src, test_subset, count=4)
-
-    cfg = yaml.safe_load(cfg_src.read_text(encoding="utf-8"))
-    cfg["DATA"]["data_dir"] = str(data_dir)
-    cfg["SYSTEM"]["device"] = "cpu"
-    cfg["SYSTEM"]["GPU"] = 0
-    cfg["SYSTEM"]["save_dir"] = str(tmp_path / "classification-checkpoints")
-    cfg["SYSTEM"]["log_dir"] = str(tmp_path / "classification-logs")
-    cfg["TRAIN"]["epochs"] = 1
-    cfg["TRAIN"]["save_every"] = 1
-    cfg["TRAIN"]["use_weighted_loss"] = False
-    cfg["MODEL"]["backbone"]["type"] = "r3d_18"
-    cfg["MODEL"]["pretrained_model"] = "r3d_18"
-    cfg["DATA"]["train"]["dataloader"]["batch_size"] = 2
-    cfg["DATA"]["valid"]["dataloader"]["batch_size"] = 2
-    cfg["DATA"]["test"]["dataloader"]["batch_size"] = 2
-    cfg["DATA"]["train"]["dataloader"]["num_workers"] = 0
-    cfg["DATA"]["valid"]["dataloader"]["num_workers"] = 0
-    cfg["DATA"]["test"]["dataloader"]["num_workers"] = 0
-
-    cfg_path = tmp_path / "classification-subset.yaml"
-    cfg_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+def test_classification_train_and_infer_subset(
+    tmp_path,
+    monkeypatch,
+    classification_integration_assets,
+):
+    _install_classification_stubs(monkeypatch, tmp_path)
+    assets = classification_integration_assets
 
     monkeypatch.setenv("OSL_PRETRAINED_WEIGHTS", "0")
     monkeypatch.setenv("WANDB_MODE", "disabled")
 
-    api = ClassificationAPI(config=str(cfg_path), save_dir=str(tmp_path / "classification-runs"))
+    api = ClassificationModel(
+        config=assets["config"],
+    )
     checkpoint = api.train(
-        train_set=str(train_subset),
-        valid_set=str(valid_subset),
+        train_set=assets["train"],
+        valid_set=assets["valid"],
         use_wandb=False,
     )
 
     assert checkpoint is not None
     assert Path(checkpoint).exists()
 
-    metrics = api.infer(
-        test_set=str(test_subset),
-        pretrained=checkpoint,
+    predictions = api.infer(
+        test_set=assets["test"],
+        weights=checkpoint,
+        use_wandb=False,
+    )
+    assert isinstance(predictions, dict)
+    assert predictions.get("task") == "action_classification"
+
+    metrics = api.evaluate(
+        test_set=assets["test"],
         use_wandb=False,
     )
     assert isinstance(metrics, dict)
 
 
-def test_localization_train_and_infer_subset(tmp_path, monkeypatch):
-    _require_enabled()
-
-    cfg_src = Path(
-        "/home/vorajv/opensportslib/opensportslib/config/localization-json_netvlad++_resnetpca512.yaml"
-    )
-    data_root = Path("/home/vorajv/soccernetpro/SoccerNet/SNAS-ResNET_PCA512")
-
-    train_src = data_root / "annotations-train.json"
-    valid_src = data_root / "annotations-valid.json"
-    test_src = data_root / "annotations-test.json"
-
-    for path in (cfg_src, train_src, valid_src, test_src):
-        if not path.exists():
-            pytest.skip(f"Required file not found: {path}")
-
-    train_subset = tmp_path / "localization-train-subset.json"
-    valid_subset = tmp_path / "localization-valid-subset.json"
-    test_subset = tmp_path / "localization-test-subset.json"
-    _subset_json(train_src, train_subset, count=1)
-    _subset_json(valid_src, valid_subset, count=1)
-    _subset_json(test_src, test_subset, count=1)
-
-    cfg = yaml.safe_load(cfg_src.read_text(encoding="utf-8"))
-    cfg["dali"] = False
-    cfg["DATA"]["data_dir"] = str(data_root)
-    cfg["DATA"]["mixup"] = False
-
-    for split in ("train", "valid", "test"):
-        cfg["DATA"][split]["video_path"] = str(data_root)
-        cfg["DATA"][split]["dataloader"]["batch_size"] = 8 if split != "test" else 1
-        cfg["DATA"][split]["dataloader"]["num_workers"] = 0
-        cfg["DATA"][split]["dataloader"]["pin_memory"] = False
-
-    cfg["DATA"]["train"]["path"] = str(train_subset)
-    cfg["DATA"]["valid"]["path"] = str(valid_subset)
-    cfg["DATA"]["test"]["path"] = str(test_subset)
-
-    cfg["TRAIN"]["max_epochs"] = 1
-    cfg["TRAIN"]["evaluation_frequency"] = 1
-    cfg["TRAIN"]["batch_size"] = 8
-
-    cfg["SYSTEM"]["device"] = "cpu"
-    cfg["SYSTEM"]["GPU"] = 0
-    cfg["SYSTEM"]["save_dir"] = str(tmp_path / "localization-checkpoints")
-    cfg["SYSTEM"]["log_dir"] = str(tmp_path / "localization-logs")
-    cfg["SYSTEM"]["work_dir"] = cfg["SYSTEM"]["save_dir"]
-
-    cfg_path = tmp_path / "localization-subset.yaml"
-    cfg_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+def test_localization_train_and_infer_subset(
+    tmp_path,
+    monkeypatch,
+    localization_integration_assets,
+):
+    _install_localization_stubs(monkeypatch, tmp_path)
+    assets = localization_integration_assets
 
     monkeypatch.setenv("OSL_PRETRAINED_WEIGHTS", "0")
     monkeypatch.setenv("WANDB_MODE", "disabled")
 
-    api = LocalizationAPI(config=str(cfg_path), save_dir=str(tmp_path / "localization-runs"))
+    api = LocalizationModel(
+        config=assets["config"],
+    )
     checkpoint = api.train(
-        train_set=str(train_subset),
-        valid_set=str(valid_subset),
+        train_set=assets["train"],
+        valid_set=assets["valid"],
         use_wandb=False,
     )
     assert checkpoint is not None
     assert Path(checkpoint).exists()
 
-    metrics = api.infer(
-        test_set=str(test_subset),
-        pretrained=checkpoint,
+    predictions = api.infer(
+        test_set=assets["test"],
+        weights=checkpoint,
         use_wandb=False,
     )
-    # Localization evaluator may return a formatted table string or a dict,
-    # depending on evaluator backend/version.
-    assert isinstance(metrics, (dict, str))
+    assert isinstance(predictions, dict)
+    assert predictions.get("task") == "localization"
+
+    metrics = api.evaluate(
+        test_set=assets["test"],
+        use_wandb=False,
+    )
+    assert isinstance(metrics, dict)

--- a/tests/test_task_model_api_contract.py
+++ b/tests/test_task_model_api_contract.py
@@ -1,0 +1,73 @@
+import inspect
+
+from opensportslib.apis import ClassificationModel, LocalizationModel
+
+
+def test_method_signatures_expose_weights_and_no_pretrained_in_signature(
+    classification_config_path,
+    localization_config_path,
+):
+    cls_api = ClassificationModel(config=classification_config_path)
+    loc_api = LocalizationModel(config=localization_config_path)
+
+    for api in (cls_api, loc_api):
+        for method_name in ("load_weights", "train", "infer", "evaluate"):
+            sig = inspect.signature(getattr(api, method_name))
+            assert "weights" in sig.parameters
+            assert "pretrained" not in sig.parameters
+            assert any(
+                p.kind == inspect.Parameter.VAR_KEYWORD
+                for p in sig.parameters.values()
+            )
+
+    load_sig = inspect.signature(cls_api.load_weights)
+    assert "optimizer" not in load_sig.parameters
+    assert "scheduler" not in load_sig.parameters
+
+    infer_sig = inspect.signature(cls_api.infer)
+    assert "output_path" not in infer_sig.parameters
+
+    eval_sig = inspect.signature(cls_api.evaluate)
+    assert "predictions" not in eval_sig.parameters
+
+    loc_train_sig = inspect.signature(loc_api.train)
+    loc_infer_sig = inspect.signature(loc_api.infer)
+    loc_eval_sig = inspect.signature(loc_api.evaluate)
+    assert "use_ddp" not in loc_train_sig.parameters
+    assert "use_ddp" not in loc_infer_sig.parameters
+    assert "use_ddp" not in loc_eval_sig.parameters
+
+    save_sig = inspect.signature(cls_api.save_predictions)
+    assert "output_path" in save_sig.parameters
+    assert "predictions" in save_sig.parameters
+    assert save_sig.parameters["predictions"].default is inspect._empty
+
+
+def test_save_predictions_writes_dict_payload(classification_config_path, tmp_path):
+    api = ClassificationModel(config=classification_config_path)
+    out_path = tmp_path / "predictions.json"
+
+    saved = api.save_predictions(
+        output_path=str(out_path),
+        predictions={"items": [{"label": "PASS", "confidence": 0.9}]},
+    )
+
+    assert saved == str(out_path)
+    assert out_path.exists()
+
+
+def test_constructor_is_minimal_and_sets_run_id(
+    classification_config_path,
+    localization_config_path,
+):
+    cls_sig = inspect.signature(ClassificationModel)
+    loc_sig = inspect.signature(LocalizationModel)
+
+    assert list(cls_sig.parameters.keys()) == ["config", "weights"]
+    assert list(loc_sig.parameters.keys()) == ["config", "weights"]
+
+    cls_api = ClassificationModel(config=classification_config_path)
+    loc_api = LocalizationModel(config=localization_config_path)
+
+    assert cls_api.run_id
+    assert loc_api.run_id


### PR DESCRIPTION
Refactor the OpenSportsLib API layer to make task wrappers cleaner, more consistent, and easier to extend.

- Introduce `BaseTaskModel` as the shared task wrapper contract (`load_weights`, `train`, `infer`, `evaluate`, `save_predictions`)
- Move common constructor setup into `BaseTaskModel.__init__` (config load/expand, RUN_ID, shared state fields, optional weight loading)
- Standardize public task wrappers as model classes: `ClassificationModel` and `LocalizationModel`
- Keep task-specific orchestration in each wrapper, with local split path resolution (`arg -> DATA.<split>.path -> DATA.annotations.<split>`)
- Make `infer()` prediction-only and return in-memory OSL JSON payloads
- Remove prediction saving side effects from `infer()`; saving is now explicit via `save_predictions(output_path, predictions)`
- Remove unused `use_ddp` from localization API (classification-only concern)
- Simplify signatures/behavior by removing deprecated/extra API helper logic
- Update docs, quickstart examples, and tests to match the new API contract

BREAKING CHANGES:
- `infer()` no longer accepts `output_path`
- `LocalizationModel.train/infer/evaluate` no longer accept `use_ddp`
- Constructor override support was removed (constructor is now `config`, optional `weights`)
- API usage is class-based (`ClassificationModel`, `LocalizationModel`)