### PR TITLE
feat: Add rule-based model support and inference script

### DIFF
--- a/docs/data/osl-json-format.md
+++ b/docs/data/osl-json-format.md
@@ -125,9 +125,18 @@ Supported input types used by current OpenSportsLib workflows:
 | `video` | `clips/clip_0001.mp4` | Raw video clip or full game video. |
 | `frames_npy` | `frames/clip_0001.npy` | NumPy frame array. The legacy alias `frame_npy` is normalized by annotation tooling. |
 | `tracking_parquet` | `tracking/clip_0001.parquet` | Parquet tracking data. |
+| `player_centroids_h5` | `tracking/live_centroids.h5` | Columnar H5 player centroid rows keyed by `timestamp_utc`, with player `x/y` coordinates. |
+| `player_joints_h5` | `tracking/live_joints.h5` | Columnar H5 player joint rows keyed by `timestamp_utc`, with joint columns named like `nose_x`, `nose_y`, `nose_z`. |
 
 `fps` is recommended for video and frame-array inputs. Tracking inputs can also
 include `fps` as a fallback when timestamps are not available.
+
+H5 player tracking inputs may include `ball_path` to point at a synchronized
+ball H5 file. Ball files are resolved relative to the same split `source_path`
+as `path`, unless an absolute path is provided. H5 loaders use `timestamp_utc`
+as the source of truth and can clip each sample with optional
+`data[].metadata.start_utc` and `data[].metadata.end_utc` values. When those
+metadata fields are absent, the loader uses the available H5 timestamp range.
 
 ### Relative Path Resolution
 
@@ -184,6 +193,11 @@ or modality.
     {
       "type": "tracking_parquet",
       "path": "tracking/play_0001.parquet"
+    },
+    {
+      "type": "player_centroids_h5",
+      "path": "tracking/live_centroids.h5",
+      "ball_path": "tracking/live_ball.h5"
     }
   ]
 }
@@ -467,6 +481,45 @@ Grouped question/answer annotations:
         "effective_fps": 2.0,
         "window_size": 16,
         "frame_interval": 15
+      }
+    }
+  ]
+}
+```
+
+## H5 Tracking Example
+
+```json
+{
+  "version": "2.0",
+  "date": "2026-07-20",
+  "task": "action_classification",
+  "dataset_name": "soccer-h5-tracking-demo",
+  "modalities": ["player_centroids_h5"],
+  "labels": {
+    "action": {
+      "type": "single_label",
+      "labels": ["header", "other"]
+    }
+  },
+  "data": [
+    {
+      "id": "match_01_window_0001",
+      "inputs": [
+        {
+          "type": "player_centroids_h5",
+          "path": "live_centroids.h5",
+          "ball_path": "live_ball.h5"
+        }
+      ],
+      "metadata": {
+        "start_utc": "2022-12-03 16:00:02.000000",
+        "end_utc": "2022-12-03 16:00:04.000000"
+      },
+      "labels": {
+        "action": {
+          "label": "header"
+        }
       }
     }
   ]

--- a/opensportslib/apis/classification.py
+++ b/opensportslib/apis/classification.py
@@ -17,6 +17,17 @@ from opensportslib.core.config.accessors import (
 )
 from opensportslib.core.utils.config import expand
 
+
+def _is_tracking_graph_modality(modality):
+    return str(modality).lower() in {
+        "tracking",
+        "tracking_parquet",
+        "tracking_h5",
+        "player_centroids_h5",
+        "player_joints_h5",
+    }
+
+
 class ClassificationModel(BaseTaskModel):
     """Top-level task wrapper for classification."""
 
@@ -100,7 +111,7 @@ class ClassificationModel(BaseTaskModel):
         trainer.model = model
 
         modality = get_data_modality(config)
-        use_tracking_collate = modality in {"tracking", "tracking_parquet"}
+        use_tracking_collate = _is_tracking_graph_modality(modality)
         logging.info(
             "Worker setup | mode=%s | modality=%s | tracking_collate=%s",
             mode,

--- a/opensportslib/apis/localization.py
+++ b/opensportslib/apis/localization.py
@@ -14,6 +14,7 @@ from opensportslib.core.config.accessors import (
     get_split_annotation_path,
     get_split_cfg,
     set_split_annotation_path,
+    get_model_family,
 )
 from opensportslib.core.utils.config import expand
 
@@ -169,6 +170,11 @@ class LocalizationModel(BaseTaskModel):
         import torch
 
         del kwargs
+
+        if str(get_model_family(self.config)).lower() == "rulebased":
+            raise NotImplementedError(
+                "RuleBased localization models are inference-only; call infer() instead of train()."
+            )
 
         train_set = self._resolve_split_path("train", train_set)
         valid_set = self._resolve_split_path("valid", valid_set)

--- a/opensportslib/configs/localization/h5_header_distance.yaml
+++ b/opensportslib/configs/localization/h5_header_distance.yaml
@@ -11,14 +11,14 @@ SYSTEM:
 DATA:
   common:
     dataset_name: h5_headers
-    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    data_root: ./data
     classes:
       - header
     splits:
       test:
         type: H5OSLJsonSpotting
-        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
-        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        annotation_path: ./data/h5.json
+        source_path: ./data
         dataloader:
           batch_size: 1
           shuffle: false

--- a/opensportslib/configs/localization/h5_header_distance.yaml
+++ b/opensportslib/configs/localization/h5_header_distance.yaml
@@ -1,0 +1,93 @@
+TASK: localization
+VERSION: 2
+
+SYSTEM:
+  paths:
+    work_dir: ./outputs/header_spotting_distance
+  device: cpu
+  gpu:
+    count: 0
+
+DATA:
+  common:
+    dataset_name: h5_headers
+    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    classes:
+      - header
+    splits:
+      test:
+        type: H5OSLJsonSpotting
+        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
+        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        dataloader:
+          batch_size: 1
+          shuffle: false
+          num_workers: 0
+          pin_memory: false
+  inputs:
+    tracking:
+      modality: player_joints_h5
+      representation: raw
+      source:
+        format: h5
+      sampling: {}
+      transform: {}
+      augmentations: {}
+      params: {}
+
+MODEL:
+  metadata:
+    family: RuleBased
+    runner:
+      type: runner_h5_header_rule
+  components:
+    rule:
+      kind: algorithm
+      source:
+        provider: opensportslib
+        registry: rule_based
+        name: h5_header_distance
+      params:
+        label: header
+        head_name: action
+        distance_threshold_m: 0.5
+        min_confidence: 0.5
+        confidence_mode: linear_inverse_distance
+        confidence_power: 1.0
+        nms_window_ms: 1000
+        nms_scope: sample
+        ball_tolerance_ms: 60
+        chunk_size: 100000
+        head_joints: [nose, neck, l_eye, r_eye, l_ear, r_ear]
+        required_input_type: player_joints_h5
+        ball_path_field: ball_path
+        timestamp_field: timestamp_utc
+        output_task: action_spotting
+        include_diagnostics: true
+        position_ms_origin: joint_h5_start
+        metadata_start_field: start_utc
+        metadata_end_field: end_utc
+        ball_coordinate_fields: [x, y, z]
+        joint_coordinate_suffixes: [x, y, z]
+        identity_fields: [player_id, jersey_number, team_id, is_home]
+        invalid_coordinate_values: [-200.0]
+        sideline_filter_enabled: true
+        pitch_half_width_m: 50.0
+        sideline_exclusion_m: 1.0
+        sideline_reference: ball_y
+        trajectory_filter_enabled: false
+        trajectory_change_mode: either_angle_or_speed
+        trajectory_pre_window_ms: 200
+        trajectory_post_window_ms: 200
+        trajectory_min_angle_deg: 25.0
+        trajectory_min_speed_delta_ratio: 0.25
+        trajectory_min_vector_norm_m: 0.05
+        trajectory_use_xy_only: false
+        confidence_output_key: confidence_score
+  topology: []
+
+TRAIN:
+  trainer:
+    type: trainer_rule_based
+  execution:
+    enabled: false

--- a/opensportslib/configs/localization/h5_header_distance_angle.yaml
+++ b/opensportslib/configs/localization/h5_header_distance_angle.yaml
@@ -11,14 +11,14 @@ SYSTEM:
 DATA:
   common:
     dataset_name: h5_headers
-    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    data_root: ./data
     classes:
       - header
     splits:
       test:
         type: H5OSLJsonSpotting
-        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
-        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        annotation_path: ./data/h5.json
+        source_path: ./data
         dataloader:
           batch_size: 1
           shuffle: false

--- a/opensportslib/configs/localization/h5_header_distance_angle.yaml
+++ b/opensportslib/configs/localization/h5_header_distance_angle.yaml
@@ -1,0 +1,93 @@
+TASK: localization
+VERSION: 2
+
+SYSTEM:
+  paths:
+    work_dir: ./outputs/header_spotting_distance_angle
+  device: cpu
+  gpu:
+    count: 0
+
+DATA:
+  common:
+    dataset_name: h5_headers
+    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    classes:
+      - header
+    splits:
+      test:
+        type: H5OSLJsonSpotting
+        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
+        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        dataloader:
+          batch_size: 1
+          shuffle: false
+          num_workers: 0
+          pin_memory: false
+  inputs:
+    tracking:
+      modality: player_joints_h5
+      representation: raw
+      source:
+        format: h5
+      sampling: {}
+      transform: {}
+      augmentations: {}
+      params: {}
+
+MODEL:
+  metadata:
+    family: RuleBased
+    runner:
+      type: runner_h5_header_rule
+  components:
+    rule:
+      kind: algorithm
+      source:
+        provider: opensportslib
+        registry: rule_based
+        name: h5_header_distance_angle
+      params:
+        label: header
+        head_name: action
+        distance_threshold_m: 0.5
+        min_confidence: 0.5
+        confidence_mode: linear_inverse_distance
+        confidence_power: 1.0
+        nms_window_ms: 1000
+        nms_scope: sample
+        ball_tolerance_ms: 60
+        chunk_size: 100000
+        head_joints: [nose, neck, l_eye, r_eye, l_ear, r_ear]
+        required_input_type: player_joints_h5
+        ball_path_field: ball_path
+        timestamp_field: timestamp_utc
+        output_task: action_spotting
+        include_diagnostics: true
+        position_ms_origin: joint_h5_start
+        metadata_start_field: start_utc
+        metadata_end_field: end_utc
+        ball_coordinate_fields: [x, y, z]
+        joint_coordinate_suffixes: [x, y, z]
+        identity_fields: [player_id, jersey_number, team_id, is_home]
+        invalid_coordinate_values: [-200.0]
+        sideline_filter_enabled: true
+        pitch_half_width_m: 50.0
+        sideline_exclusion_m: 1.0
+        sideline_reference: ball_y
+        trajectory_filter_enabled: true
+        trajectory_change_mode: angle
+        trajectory_pre_window_ms: 200
+        trajectory_post_window_ms: 200
+        trajectory_min_angle_deg: 25.0
+        trajectory_min_speed_delta_ratio: 0.25
+        trajectory_min_vector_norm_m: 0.05
+        trajectory_use_xy_only: false
+        confidence_output_key: confidence_score
+  topology: []
+
+TRAIN:
+  trainer:
+    type: trainer_rule_based
+  execution:
+    enabled: false

--- a/opensportslib/configs/localization/h5_header_distance_speed.yaml
+++ b/opensportslib/configs/localization/h5_header_distance_speed.yaml
@@ -11,14 +11,14 @@ SYSTEM:
 DATA:
   common:
     dataset_name: h5_headers
-    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    data_root: ./data
     classes:
       - header
     splits:
       test:
         type: H5OSLJsonSpotting
-        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
-        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        annotation_path: ./data/h5.json
+        source_path: ./data
         dataloader:
           batch_size: 1
           shuffle: false

--- a/opensportslib/configs/localization/h5_header_distance_speed.yaml
+++ b/opensportslib/configs/localization/h5_header_distance_speed.yaml
@@ -1,0 +1,93 @@
+TASK: localization
+VERSION: 2
+
+SYSTEM:
+  paths:
+    work_dir: ./outputs/header_spotting_distance_speed
+  device: cpu
+  gpu:
+    count: 0
+
+DATA:
+  common:
+    dataset_name: h5_headers
+    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    classes:
+      - header
+    splits:
+      test:
+        type: H5OSLJsonSpotting
+        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
+        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        dataloader:
+          batch_size: 1
+          shuffle: false
+          num_workers: 0
+          pin_memory: false
+  inputs:
+    tracking:
+      modality: player_joints_h5
+      representation: raw
+      source:
+        format: h5
+      sampling: {}
+      transform: {}
+      augmentations: {}
+      params: {}
+
+MODEL:
+  metadata:
+    family: RuleBased
+    runner:
+      type: runner_h5_header_rule
+  components:
+    rule:
+      kind: algorithm
+      source:
+        provider: opensportslib
+        registry: rule_based
+        name: h5_header_distance_speed
+      params:
+        label: header
+        head_name: action
+        distance_threshold_m: 0.5
+        min_confidence: 0.5
+        confidence_mode: linear_inverse_distance
+        confidence_power: 1.0
+        nms_window_ms: 1000
+        nms_scope: sample
+        ball_tolerance_ms: 60
+        chunk_size: 100000
+        head_joints: [nose, neck, l_eye, r_eye, l_ear, r_ear]
+        required_input_type: player_joints_h5
+        ball_path_field: ball_path
+        timestamp_field: timestamp_utc
+        output_task: action_spotting
+        include_diagnostics: true
+        position_ms_origin: joint_h5_start
+        metadata_start_field: start_utc
+        metadata_end_field: end_utc
+        ball_coordinate_fields: [x, y, z]
+        joint_coordinate_suffixes: [x, y, z]
+        identity_fields: [player_id, jersey_number, team_id, is_home]
+        invalid_coordinate_values: [-200.0]
+        sideline_filter_enabled: true
+        pitch_half_width_m: 50.0
+        sideline_exclusion_m: 1.0
+        sideline_reference: ball_y
+        trajectory_filter_enabled: true
+        trajectory_change_mode: speed
+        trajectory_pre_window_ms: 200
+        trajectory_post_window_ms: 200
+        trajectory_min_angle_deg: 25.0
+        trajectory_min_speed_delta_ratio: 0.25
+        trajectory_min_vector_norm_m: 0.05
+        trajectory_use_xy_only: false
+        confidence_output_key: confidence_score
+  topology: []
+
+TRAIN:
+  trainer:
+    type: trainer_rule_based
+  execution:
+    enabled: false

--- a/opensportslib/configs/localization/h5_header_distance_speed_angle.yaml
+++ b/opensportslib/configs/localization/h5_header_distance_speed_angle.yaml
@@ -1,0 +1,93 @@
+TASK: localization
+VERSION: 2
+
+SYSTEM:
+  paths:
+    work_dir: ./outputs/header_spotting_distance_speed_angle
+  device: cpu
+  gpu:
+    count: 0
+
+DATA:
+  common:
+    dataset_name: h5_headers
+    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    classes:
+      - header
+    splits:
+      test:
+        type: H5OSLJsonSpotting
+        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
+        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        dataloader:
+          batch_size: 1
+          shuffle: false
+          num_workers: 0
+          pin_memory: false
+  inputs:
+    tracking:
+      modality: player_joints_h5
+      representation: raw
+      source:
+        format: h5
+      sampling: {}
+      transform: {}
+      augmentations: {}
+      params: {}
+
+MODEL:
+  metadata:
+    family: RuleBased
+    runner:
+      type: runner_h5_header_rule
+  components:
+    rule:
+      kind: algorithm
+      source:
+        provider: opensportslib
+        registry: rule_based
+        name: h5_header_distance_speed_angle
+      params:
+        label: header
+        head_name: action
+        distance_threshold_m: 0.5
+        min_confidence: 0.5
+        confidence_mode: linear_inverse_distance
+        confidence_power: 1.0
+        nms_window_ms: 1000
+        nms_scope: sample
+        ball_tolerance_ms: 60
+        chunk_size: 100000
+        head_joints: [nose, neck, l_eye, r_eye, l_ear, r_ear]
+        required_input_type: player_joints_h5
+        ball_path_field: ball_path
+        timestamp_field: timestamp_utc
+        output_task: action_spotting
+        include_diagnostics: true
+        position_ms_origin: joint_h5_start
+        metadata_start_field: start_utc
+        metadata_end_field: end_utc
+        ball_coordinate_fields: [x, y, z]
+        joint_coordinate_suffixes: [x, y, z]
+        identity_fields: [player_id, jersey_number, team_id, is_home]
+        invalid_coordinate_values: [-200.0]
+        sideline_filter_enabled: true
+        pitch_half_width_m: 50.0
+        sideline_exclusion_m: 1.0
+        sideline_reference: ball_y
+        trajectory_filter_enabled: true
+        trajectory_change_mode: both_angle_and_speed
+        trajectory_pre_window_ms: 200
+        trajectory_post_window_ms: 200
+        trajectory_min_angle_deg: 25.0
+        trajectory_min_speed_delta_ratio: 0.25
+        trajectory_min_vector_norm_m: 0.05
+        trajectory_use_xy_only: false
+        confidence_output_key: confidence_score
+  topology: []
+
+TRAIN:
+  trainer:
+    type: trainer_rule_based
+  execution:
+    enabled: false

--- a/opensportslib/configs/localization/h5_header_distance_speed_angle.yaml
+++ b/opensportslib/configs/localization/h5_header_distance_speed_angle.yaml
@@ -11,14 +11,14 @@ SYSTEM:
 DATA:
   common:
     dataset_name: h5_headers
-    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    data_root: ./data
     classes:
       - header
     splits:
       test:
         type: H5OSLJsonSpotting
-        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
-        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        annotation_path: ./data/h5.json
+        source_path: ./data
         dataloader:
           batch_size: 1
           shuffle: false

--- a/opensportslib/configs/localization/h5_header_rule.yaml
+++ b/opensportslib/configs/localization/h5_header_rule.yaml
@@ -1,0 +1,99 @@
+TASK: localization
+VERSION: 2
+
+SYSTEM:
+  paths:
+    work_dir: ./outputs/header_spotting
+  device: cpu
+  gpu:
+    count: 0
+
+DATA:
+  common:
+    dataset_name: h5_headers
+    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    classes:
+      - header
+    splits:
+      test:
+        type: H5OSLJsonSpotting
+        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
+        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        dataloader:
+          batch_size: 1
+          shuffle: false
+          num_workers: 0
+          pin_memory: false
+  inputs:
+    tracking:
+      modality: player_joints_h5
+      representation: raw
+      source:
+        format: h5
+      sampling: {}
+      transform: {}
+      augmentations: {}
+      params: {}
+
+MODEL:
+  metadata:
+    family: RuleBased
+    runner:
+      type: runner_h5_header_rule
+  components:
+    rule:
+      kind: algorithm
+      source:
+        provider: opensportslib
+        registry: rule_based
+        # Available models:
+        # - h5_header_distance
+        # - h5_header_distance_speed
+        # - h5_header_distance_angle
+        # - h5_header_distance_speed_angle
+        name: h5_header_distance_speed_angle
+      params:
+        label: header
+        head_name: action
+        distance_threshold_m: 0.20
+        min_confidence: 0.5
+        confidence_mode: linear_inverse_distance
+        confidence_power: 1.0
+        nms_window_ms: 1000
+        nms_scope: sample
+        ball_tolerance_ms: 60
+        chunk_size: 100000
+        head_joints: [nose, neck, l_eye, r_eye, l_ear, r_ear]
+        required_input_type: player_joints_h5
+        ball_path_field: ball_path
+        timestamp_field: timestamp_utc
+        output_task: action_spotting
+        include_diagnostics: true
+        created_by: h5_header_distance_speed_angle_rule
+        position_ms_origin: joint_h5_start
+        metadata_start_field: start_utc
+        metadata_end_field: end_utc
+        ball_coordinate_fields: [x, y, z]
+        joint_coordinate_suffixes: [x, y, z]
+        identity_fields: [player_id, jersey_number, team_id, is_home]
+        invalid_coordinate_values: [-200.0]
+        sideline_filter_enabled: true
+        pitch_half_width_m: 50.0
+        sideline_exclusion_m: 1.0
+        sideline_reference: ball_y
+        trajectory_filter_enabled: true
+        trajectory_change_mode: both_angle_and_speed
+        trajectory_pre_window_ms: 200
+        trajectory_post_window_ms: 200
+        trajectory_min_angle_deg: 25.0
+        trajectory_min_speed_delta_ratio: 0.25
+        trajectory_min_vector_norm_m: 0.05
+        trajectory_use_xy_only: false
+        confidence_output_key: confidence_score
+  topology: []
+
+TRAIN:
+  trainer:
+    type: trainer_rule_based
+  execution:
+    enabled: false

--- a/opensportslib/configs/localization/h5_header_rule.yaml
+++ b/opensportslib/configs/localization/h5_header_rule.yaml
@@ -11,14 +11,14 @@ SYSTEM:
 DATA:
   common:
     dataset_name: h5_headers
-    data_root: /Users/giancos/git/VideoAnnotationTool/test_data
+    data_root: ./data
     classes:
       - header
     splits:
       test:
         type: H5OSLJsonSpotting
-        annotation_path: /Users/giancos/git/VideoAnnotationTool/test_data/h5.json
-        source_path: /Users/giancos/git/VideoAnnotationTool/test_data
+        annotation_path: ./data/h5.json
+        source_path: ./data
         dataloader:
           batch_size: 1
           shuffle: false

--- a/opensportslib/core/config/accessors.py
+++ b/opensportslib/core/config/accessors.py
@@ -6,10 +6,17 @@ import os
 from types import SimpleNamespace
 from typing import Any
 
+try:
+    from omegaconf import OmegaConf
+except Exception:  # pragma: no cover - omegaconf is a runtime dependency
+    OmegaConf = None
+
 
 def _to_plain(obj: Any) -> Any:
     if obj is None:
         return None
+    if OmegaConf is not None and OmegaConf.is_config(obj):
+        return OmegaConf.to_container(obj, resolve=True)
     if isinstance(obj, dict):
         return {k: _to_plain(v) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -24,6 +31,9 @@ def _to_plain(obj: Any) -> Any:
 def _as_dict(obj: Any) -> dict[str, Any]:
     if obj is None:
         return {}
+    if OmegaConf is not None and OmegaConf.is_config(obj):
+        plain = OmegaConf.to_container(obj, resolve=True)
+        return plain if isinstance(plain, dict) else {}
     if isinstance(obj, dict):
         return {k: _to_plain(v) for k, v in obj.items()}
     if hasattr(obj, "__dict__"):

--- a/opensportslib/core/trainer/classification_trainer.py
+++ b/opensportslib/core/trainer/classification_trainer.py
@@ -69,6 +69,16 @@ def _is_frames_npy_modality(config, modality=None):
     representation = str(input_cfg.get("representation", "")).lower()
     return source_format == "npy" or representation == "frames"
 
+
+def _is_tracking_graph_modality(modality):
+    return str(modality).lower() in {
+        "tracking",
+        "tracking_parquet",
+        "tracking_h5",
+        "player_centroids_h5",
+        "player_joints_h5",
+    }
+
 # -------------------------------------------------------------------
 # base classification trainer
 # -------------------------------------------------------------------
@@ -815,7 +825,7 @@ class Trainer_Classification:
 
         is_ddp = world_size > 1
         modality = get_data_modality(self.config)
-        is_tracking_modality = modality in {"tracking", "tracking_parquet"}
+        is_tracking_modality = _is_tracking_graph_modality(modality)
         is_frames_modality = _is_frames_npy_modality(self.config, modality)
         seed = get_system_seed(self.config)
 
@@ -1128,7 +1138,7 @@ class Trainer_Classification:
                 test_sampler = None
 
             modality = get_data_modality(self.config)
-            is_tracking_modality = modality in {"tracking", "tracking_parquet"}
+            is_tracking_modality = _is_tracking_graph_modality(modality)
             is_frames_modality = _is_frames_npy_modality(self.config, modality)
             collate_fn = tracking_collate_fn if is_tracking_modality else None
             test_dataloader_cfg = get_split_dataloader_cfg(self.config, "test")

--- a/opensportslib/core/trainer/localization_trainer.py
+++ b/opensportslib/core/trainer/localization_trainer.py
@@ -546,7 +546,7 @@ class Inferer:
             return self.infer_E2E(cfg, self.model, data, dataloader)
         elif self.infer_Spotting=="infer_H5HeaderRule":
             return self.infer_H5HeaderRule(cfg, self.model, data, dataloader)
-
+        raise ValueError(f"Unsupported infer_Spotting method: {self.infer_Spotting}")
 
     def infer_common(self, cfg, model, data, dataloader=None):
         """Infer actions from data using a given model.

--- a/opensportslib/core/trainer/localization_trainer.py
+++ b/opensportslib/core/trainer/localization_trainer.py
@@ -510,6 +510,8 @@ def build_inferer(cfg, model, default_args=None):
         return Inferer(cfg=cfg, model=model, infer_Spotting="infer_SN")
     if runner_type == "runner_e2e":
         return Inferer(cfg=cfg, model=model, infer_Spotting="infer_E2E")
+    if runner_type == "runner_h5_header_rule":
+        return Inferer(cfg=cfg, model=model, infer_Spotting="infer_H5HeaderRule")
     raise ValueError(f"Unsupported localization runner type: {runner_type}")
 
 class Inferer:
@@ -542,6 +544,8 @@ class Inferer:
             return self.infer_SN(cfg, self.model, data, dataloader)
         elif self.infer_Spotting=="infer_E2E":
             return self.infer_E2E(cfg, self.model, data, dataloader)
+        elif self.infer_Spotting=="infer_H5HeaderRule":
+            return self.infer_H5HeaderRule(cfg, self.model, data, dataloader)
 
 
     def infer_common(self, cfg, model, data, dataloader=None):
@@ -643,6 +647,11 @@ class Inferer:
             logging.info(pred_recall_file)
 
         return predictions
+
+    def infer_H5HeaderRule(self, cfg, model, data, dataloader=None):
+        """Run rule-based H5 header spotting without Lightning or weights."""
+        del cfg, dataloader
+        return model.predict(data)
 
 
 def build_evaluator(cfg, default_args=None):

--- a/opensportslib/core/utils/load_annotations.py
+++ b/opensportslib/core/utils/load_annotations.py
@@ -109,7 +109,7 @@ def load_annotations(
         if label_idx is not None:
             grouped[group_id]["label"] = label_idx
         grouped[group_id]["id"] = group_id
-        grouped[group_id]["metadata"] = dict(item.get("metadata", {}) or {})
+        grouped[group_id].setdefault("metadata", dict(item.get("metadata", {}) or {}))
 
     return list(grouped.values()), label_map
 

--- a/opensportslib/core/utils/load_annotations.py
+++ b/opensportslib/core/utils/load_annotations.py
@@ -66,7 +66,8 @@ def load_annotations(
     # Group by action id (without view suffix)
     grouped = defaultdict(lambda: {
         "video_paths": [],
-        "label": None
+        "label": None,
+        "inputs": [],
     })
 
     for item in data["data"]:
@@ -101,9 +102,14 @@ def load_annotations(
             continue
 
         grouped[group_id]["video_paths"].extend(clips)
+        grouped[group_id]["inputs"].extend(
+            dict(inp) for inp in item.get("inputs", [])
+            if inp.get("type") == input_type and "path" in inp
+        )
         if label_idx is not None:
             grouped[group_id]["label"] = label_idx
         grouped[group_id]["id"] = group_id
+        grouped[group_id]["metadata"] = dict(item.get("metadata", {}) or {})
 
     return list(grouped.values()), label_map
 
@@ -587,5 +593,7 @@ def whether_infer_split(cfg):
             return True
         else:
             return False
+    elif split_type == "H5OSLJsonSpotting":
+        return bool(annotation_path and annotation_path.endswith(".json"))
     else:
         raise ValueError(f"Unknown dataset type {split_type}")

--- a/opensportslib/datasets/classification_dataset.py
+++ b/opensportslib/datasets/classification_dataset.py
@@ -36,6 +36,9 @@ from opensportslib.core.config.accessors import (
 )
 
 
+H5_TRACKING_MODALITIES = {"player_centroids_h5", "player_joints_h5", "tracking_h5"}
+
+
 # -------------------------------------------------------------
 # factory
 # -------------------------------------------------------------
@@ -59,6 +62,8 @@ def build(config, annotations_path, processor=None, split="train"):
 
     if modality in ("tracking", "tracking_parquet"):
         return TrackingDataset(config, annotations_path, split)
+    elif modality in H5_TRACKING_MODALITIES:
+        return H5TrackingDataset(config, annotations_path, split)
     elif modality in ("video", "frames_npy", "frames"):
         return VideoDataset(config, annotations_path, processor, split)
     else:
@@ -112,6 +117,10 @@ class ClassificationDataset(Dataset):
         annotation_input_type = str(get_data_modality(config)).lower()
         if annotation_input_type == "tracking":
             annotation_input_type = "tracking_parquet"
+        elif annotation_input_type == "tracking_h5":
+            annotation_input_type = get_data_params(config).get(
+                "h5_input_type", "player_centroids_h5"
+            )
         elif annotation_input_type in {"frames", "frames_npy"}:
             annotation_input_type = "frames_npy"
 
@@ -709,3 +718,154 @@ class TrackingDataset(ClassificationDataset):
             out["label"] = label
         return out
         
+
+class H5TrackingDataset(ClassificationDataset):
+    """Graph-based classification dataset for UTC-indexed player/ball H5 files."""
+
+    def __init__(self, config, annotations_path, split="train"):
+        super().__init__(config, annotations_path, processor=None, split=split)
+
+        from opensportslib.datasets.utils.tracking import build_edge_index
+
+        self._build_edge_index = build_edge_index
+        sampling_cfg = get_data_sampling(config)
+        transform_cfg = get_data_transform(config)
+        params_cfg = get_data_params(config)
+        encoder_cfg = get_component_params_by_kind(config, "encoder")
+        objects_cfg = params_cfg.get("objects", {}) or {}
+
+        self.modality = get_data_modality(config).lower()
+        if self.modality == "tracking_h5":
+            self.modality = params_cfg.get("h5_input_type", "player_centroids_h5")
+
+        self.num_frames = sampling_cfg.get("num_frames")
+        self.stride_ms = sampling_cfg.get("stride_ms")
+        self.target_fps = sampling_cfg.get("target_fps")
+        self.normalize = transform_cfg.get("normalize", False)
+        self.edge_type = encoder_cfg.get("edge_type", "full")
+        self.k = encoder_cfg.get("k")
+        self.r = encoder_cfg.get("radius", encoder_cfg.get("r"))
+        self.timestamp_tolerance_ms = float(params_cfg.get("timestamp_tolerance_ms", 50.0))
+        self.missing_value = float(params_cfg.get("missing_value", -200.0))
+        self._pitch_half_length = float(objects_cfg.get("pitch_half_length", 85.0))
+        self._pitch_half_width = float(objects_cfg.get("pitch_half_width", 50.0))
+        self._max_ball_height = float(objects_cfg.get("max_ball_height", 30.0))
+        self._max_displacement = float(objects_cfg.get("max_displacement", 110.0))
+        self.preload_data = params_cfg.get("preload_data", False)
+
+        self.processed_samples = None
+        if self.preload_data:
+            self._preload_all_data()
+
+    def _resolve_input_path(self, path):
+        if os.path.isabs(path):
+            return path
+        return os.path.join(self.video_path, path)
+
+    def _sample_input(self, item):
+        inputs = item.get("inputs") or []
+        for input_obj in inputs:
+            if input_obj.get("type") == self.modality:
+                return input_obj
+        if inputs:
+            return inputs[0]
+        clip_paths = item.get("video_paths") or []
+        if clip_paths:
+            return {"type": self.modality, "path": clip_paths[0]}
+        raise ValueError(f"No H5 input found for sample {item.get('id', '<unknown>')}")
+
+    def _load_h5_frames(self, item):
+        from opensportslib.datasets.utils.h5_tracking import (
+            H5_FEATURE_DIM,
+            H5TrackingReader,
+            normalize_h5_features,
+        )
+
+        input_obj = self._sample_input(item)
+        player_path = self._resolve_input_path(input_obj["path"])
+        ball_path = input_obj.get("ball_path")
+        if ball_path:
+            ball_path = self._resolve_input_path(ball_path)
+
+        reader = H5TrackingReader(
+            player_path,
+            input_obj.get("type", self.modality),
+            ball_path=ball_path,
+            missing_value=self.missing_value,
+            timestamp_tolerance_ms=self.timestamp_tolerance_ms,
+        )
+        metadata = item.get("metadata", {}) or {}
+        timestamps = reader.select_timestamps(
+            start_utc=metadata.get("start_utc"),
+            end_utc=metadata.get("end_utc"),
+            num_frames=self.num_frames,
+            stride_ms=self.stride_ms,
+            target_fps=self.target_fps,
+        )
+        frames = reader.read_sequence(timestamps)
+
+        if self.normalize and frames:
+            frames = [
+                frame.__class__(
+                    frame.timestamp,
+                    normalize_h5_features(
+                        frame.features[None, :, :],
+                        pitch_half_length=self._pitch_half_length,
+                        pitch_half_width=self._pitch_half_width,
+                        max_height=self._max_ball_height,
+                        max_displacement=self._max_displacement,
+                        missing_value=self.missing_value,
+                    )[0],
+                    frame.entity_ids,
+                    frame.positions,
+                )
+                for frame in frames
+            ]
+
+        return frames, H5_FEATURE_DIM
+
+    def _preload_all_data(self):
+        print(f"Preloading {len(self.samples)} {self.split} H5 samples into memory...")
+        self.processed_samples = [self._materialize_sample(item) for item in tqdm(self.samples)]
+
+    def __getitem__(self, idx):
+        if self.preload_data:
+            return self.processed_samples[idx]
+        return self._materialize_sample(self.samples[idx])
+
+    def _materialize_sample(self, item):
+        try:
+            from torch_geometric.data import Data
+        except ImportError as exc:
+            raise ImportError(
+                "torch-geometric is required for H5 tracking graph inputs. "
+                "Run: `opensportslib setup --pyg` to install the correct version "
+                "based on your system (PyTorch & CUDA compatible)."
+            ) from exc
+
+        frames, _ = self._load_h5_frames(item)
+        graphs = []
+        for frame in frames:
+            edge_index = self._build_edge_index(
+                frame.features,
+                frame.positions,
+                self.edge_type,
+                self.k,
+                self.r,
+            )
+            graphs.append(
+                Data(
+                    x=torch.tensor(frame.features, dtype=torch.float),
+                    edge_index=torch.tensor(edge_index, dtype=torch.long),
+                )
+            )
+
+        out = {
+            "graphs": graphs,
+            "seq_len": len(graphs),
+            "id": item["id"],
+        }
+        label = item.get("label", None)
+        if label is not None:
+            out["label"] = label
+        return out

--- a/opensportslib/datasets/localization_dataset.py
+++ b/opensportslib/datasets/localization_dataset.py
@@ -408,6 +408,12 @@ class LocalizationDataset(Dataset):
                 overlap_len=cfg.overlap_len,
                 crop_dim=self.data_cfg.crop_dim,
             )
+        elif dataset_type == "H5OSLJsonSpotting":
+            from opensportslib.models.base.rule_based import H5OSLJsonSpottingDataset
+            dataset = H5OSLJsonSpottingDataset(
+                annotation_path=annotation_path,
+                source_path=source_path,
+            )
         else:
             dataset = None
         return dataset
@@ -428,6 +434,8 @@ class LocalizationDataset(Dataset):
             random.seed(id + 100 * 100)
         if dali:
             return dataset
+        if getattr(dataset, "rule_based_no_dataloader", False):
+            return None
         dataloader = torch.utils.data.DataLoader(
             dataset,
             batch_size=cfg.batch_size,

--- a/opensportslib/datasets/utils/h5_tracking.py
+++ b/opensportslib/datasets/utils/h5_tracking.py
@@ -129,6 +129,8 @@ class H5TrackingReader:
         stride_ms: float | None = None,
         target_fps: float | None = None,
     ) -> np.ndarray:
+        if self.player_unique_timestamps.size == 0:
+            raise ValueError(f"Player H5 input has no timestamps: {self.player_path}")
         start = parse_utc(start_utc) if start_utc else self.player_unique_timestamps[0]
         end = parse_utc(end_utc) if end_utc else self.player_unique_timestamps[-1]
 

--- a/opensportslib/datasets/utils/h5_tracking.py
+++ b/opensportslib/datasets/utils/h5_tracking.py
@@ -1,0 +1,336 @@
+"""Utilities for UTC-indexed H5 player and ball tracking inputs."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import h5py
+import numpy as np
+
+from opensportslib.datasets.utils.tracking import MISSING_VALUE, MISSING_VALUE_NORMALIZED
+
+
+H5_FEATURE_DIM = 10
+H5_FEATURE_LAYOUT = (
+    "x",
+    "y",
+    "z",
+    "is_ball",
+    "is_home",
+    "is_away",
+    "dx",
+    "dy",
+    "dz",
+    "is_joint",
+)
+
+
+def parse_utc(value) -> np.datetime64:
+    """Parse UTC-ish H5/JSON timestamp values into microsecond datetime64."""
+    if isinstance(value, np.datetime64):
+        return value.astype("datetime64[us]")
+    if isinstance(value, (bytes, np.bytes_)):
+        value = value.decode("utf-8")
+    value = str(value).strip()
+    if not value:
+        raise ValueError("Empty UTC timestamp")
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return np.datetime64(dt, "us")
+
+
+def _decode_scalar(value) -> str:
+    if isinstance(value, (bytes, np.bytes_)):
+        return value.decode("utf-8")
+    return str(value)
+
+
+def _read_column(file_obj: h5py.File, key: str, indices: np.ndarray, default=None):
+    if key not in file_obj:
+        return np.full(len(indices), default, dtype=object)
+    return file_obj[key][indices]
+
+
+def _build_timestamp_index(path: str | Path):
+    with h5py.File(path, "r") as f:
+        if "timestamp_utc" not in f:
+            raise ValueError(f"H5 file is missing required dataset 'timestamp_utc': {path}")
+        raw = f["timestamp_utc"][:]
+
+    timestamps = np.array([parse_utc(value) for value in raw], dtype="datetime64[us]")
+    index = defaultdict(list)
+    for row_idx, timestamp in enumerate(timestamps):
+        index[timestamp.astype("int64").item()].append(row_idx)
+    compact_index = {
+        timestamp_us: np.asarray(indices, dtype=np.int64)
+        for timestamp_us, indices in index.items()
+    }
+    unique_timestamps = np.array(
+        sorted(compact_index.keys()), dtype="datetime64[us]"
+    )
+    return timestamps, compact_index, unique_timestamps
+
+
+@dataclass(frozen=True)
+class H5Frame:
+    timestamp: np.datetime64
+    features: np.ndarray
+    entity_ids: list[str]
+    positions: list[str]
+
+
+class H5TrackingReader:
+    """Lazy reader for columnar player tracking H5 files keyed by UTC."""
+
+    def __init__(
+        self,
+        player_path: str | Path,
+        modality: str,
+        ball_path: str | Path | None = None,
+        *,
+        missing_value: float = MISSING_VALUE,
+        timestamp_tolerance_ms: float = 50.0,
+    ):
+        self.player_path = str(player_path)
+        self.ball_path = str(ball_path) if ball_path else None
+        self.modality = str(modality).lower()
+        self.missing_value = float(missing_value)
+        self.timestamp_tolerance = np.timedelta64(int(timestamp_tolerance_ms * 1000), "us")
+
+        (
+            self.player_timestamps,
+            self.player_index,
+            self.player_unique_timestamps,
+        ) = _build_timestamp_index(self.player_path)
+
+        self.ball_timestamps = None
+        self.ball_index = {}
+        self.ball_unique_timestamps = np.array([], dtype="datetime64[us]")
+        if self.ball_path is not None:
+            (
+                self.ball_timestamps,
+                self.ball_index,
+                self.ball_unique_timestamps,
+            ) = _build_timestamp_index(self.ball_path)
+
+    def select_timestamps(
+        self,
+        *,
+        start_utc=None,
+        end_utc=None,
+        num_frames: int | None = None,
+        stride_ms: float | None = None,
+        target_fps: float | None = None,
+    ) -> np.ndarray:
+        start = parse_utc(start_utc) if start_utc else self.player_unique_timestamps[0]
+        end = parse_utc(end_utc) if end_utc else self.player_unique_timestamps[-1]
+
+        if self.ball_path and self.ball_unique_timestamps.size:
+            if start_utc is None:
+                start = max(start, self.ball_unique_timestamps[0])
+            if end_utc is None:
+                end = min(end, self.ball_unique_timestamps[-1])
+
+        candidates = self.player_unique_timestamps[
+            (self.player_unique_timestamps >= start) & (self.player_unique_timestamps <= end)
+        ]
+        if candidates.size == 0:
+            raise ValueError(
+                f"No player H5 timestamps found in requested UTC range: {start} to {end}"
+            )
+
+        stride_us = None
+        if stride_ms:
+            stride_us = int(float(stride_ms) * 1000)
+        elif target_fps:
+            stride_us = int(1_000_000 / float(target_fps))
+
+        if stride_us and stride_us > 0:
+            selected = []
+            next_allowed = candidates[0]
+            stride = np.timedelta64(stride_us, "us")
+            for timestamp in candidates:
+                if timestamp >= next_allowed:
+                    selected.append(timestamp)
+                    next_allowed = timestamp + stride
+            candidates = np.asarray(selected, dtype="datetime64[us]")
+
+        if num_frames is not None and int(num_frames) > 0 and candidates.size > int(num_frames):
+            if stride_us:
+                candidates = candidates[: int(num_frames)]
+            else:
+                indices = np.linspace(0, candidates.size - 1, int(num_frames))
+                candidates = candidates[np.round(indices).astype(np.int64)]
+
+        return candidates
+
+    def read_sequence(self, timestamps: Iterable[np.datetime64]) -> list[H5Frame]:
+        frames = [self._read_player_frame(timestamp) for timestamp in timestamps]
+        if self.ball_path is not None:
+            frames = [self._append_ball(frame) for frame in frames]
+        return _compute_deltas(frames, missing_value=self.missing_value)
+
+    def _row_indices(self, timestamp: np.datetime64) -> np.ndarray:
+        key = timestamp.astype("datetime64[us]").astype("int64").item()
+        return self.player_index.get(key, np.asarray([], dtype=np.int64))
+
+    def _read_player_frame(self, timestamp: np.datetime64) -> H5Frame:
+        indices = self._row_indices(timestamp)
+        if indices.size == 0:
+            return H5Frame(timestamp, np.empty((0, H5_FEATURE_DIM), dtype=np.float32), [], [])
+
+        with h5py.File(self.player_path, "r") as f:
+            if self.modality == "player_joints_h5":
+                features, entity_ids, positions = self._read_joint_nodes(f, indices)
+            else:
+                features, entity_ids, positions = self._read_centroid_nodes(f, indices)
+        return H5Frame(timestamp, features, entity_ids, positions)
+
+    def _read_centroid_nodes(self, f: h5py.File, indices: np.ndarray):
+        features = np.full((len(indices), H5_FEATURE_DIM), self.missing_value, dtype=np.float32)
+        features[:, 3] = 0.0
+        is_home_values = _read_column(f, "is_home", indices, default=-1)
+
+        features[:, 0] = _read_column(f, "x", indices, default=self.missing_value).astype(np.float32)
+        features[:, 1] = _read_column(f, "y", indices, default=self.missing_value).astype(np.float32)
+        features[:, 2] = self.missing_value
+        features[:, 4] = np.asarray(is_home_values == 1, dtype=np.float32)
+        features[:, 5] = np.asarray(is_home_values == 0, dtype=np.float32)
+        features[:, 6:9] = 0.0
+        features[:, 9] = 0.0
+
+        player_ids = _read_column(f, "player_id", indices, default="")
+        jersey = _read_column(f, "jersey_number", indices, default="")
+        entity_ids = []
+        for row_offset, (player_id, jersey_number, is_home) in enumerate(
+            zip(player_ids, jersey, is_home_values)
+        ):
+            player_id = _decode_scalar(player_id)
+            jersey_number = _decode_scalar(jersey_number)
+            side = "home" if is_home == 1 else "away" if is_home == 0 else "unknown"
+            entity_ids.append(player_id or f"{side}:{jersey_number}:{row_offset}")
+        positions = [_decode_scalar(v) for v in _read_column(f, "role_name", indices, default="")]
+        return features, entity_ids, positions
+
+    def _read_joint_nodes(self, f: h5py.File, indices: np.ndarray):
+        joint_names = sorted(
+            key[:-2]
+            for key in f.keys()
+            if key.endswith("_x") and f"{key[:-2]}_y" in f and f"{key[:-2]}_z" in f
+        )
+        is_home_values = _read_column(f, "is_home", indices, default=-1)
+        player_ids = _read_column(f, "player_id", indices, default="")
+        jersey = _read_column(f, "jersey_number", indices, default="")
+        role_names = _read_column(f, "role_name", indices, default="")
+
+        node_count = len(indices) * len(joint_names)
+        features = np.full((node_count, H5_FEATURE_DIM), self.missing_value, dtype=np.float32)
+        entity_ids = []
+        positions = []
+        out_idx = 0
+        for row_offset, row_idx in enumerate(indices):
+            player_id = _decode_scalar(player_ids[row_offset])
+            jersey_number = _decode_scalar(jersey[row_offset])
+            is_home = is_home_values[row_offset]
+            side = "home" if is_home == 1 else "away" if is_home == 0 else "unknown"
+            player_key = player_id or f"{side}:{jersey_number}:{row_offset}"
+            for joint_name in joint_names:
+                features[out_idx, 0] = f[f"{joint_name}_x"][row_idx]
+                features[out_idx, 1] = f[f"{joint_name}_y"][row_idx]
+                features[out_idx, 2] = f[f"{joint_name}_z"][row_idx]
+                features[out_idx, 3] = 0.0
+                features[out_idx, 4] = 1.0 if is_home == 1 else 0.0
+                features[out_idx, 5] = 1.0 if is_home == 0 else 0.0
+                features[out_idx, 6:9] = 0.0
+                features[out_idx, 9] = 1.0
+                entity_ids.append(f"{player_key}:{joint_name}")
+                positions.append(_decode_scalar(role_names[row_offset]))
+                out_idx += 1
+        return features, entity_ids, positions
+
+    def _append_ball(self, frame: H5Frame) -> H5Frame:
+        ball_features = np.full((1, H5_FEATURE_DIM), self.missing_value, dtype=np.float32)
+        ball_features[0, 3] = 1.0
+        ball_features[0, 4:6] = 0.0
+        ball_features[0, 6:9] = 0.0
+        ball_features[0, 9] = 0.0
+
+        nearest = self._nearest_ball_timestamp(frame.timestamp)
+        if nearest is not None:
+            key = nearest.astype("datetime64[us]").astype("int64").item()
+            row_idx = self.ball_index[key][0]
+            with h5py.File(self.ball_path, "r") as f:
+                ball_features[0, 0] = f["x"][row_idx] if "x" in f else self.missing_value
+                ball_features[0, 1] = f["y"][row_idx] if "y" in f else self.missing_value
+                ball_features[0, 2] = f["z"][row_idx] if "z" in f else self.missing_value
+
+        features = np.concatenate([ball_features, frame.features], axis=0)
+        return H5Frame(
+            timestamp=frame.timestamp,
+            features=features,
+            entity_ids=["BALL"] + frame.entity_ids,
+            positions=["BALL"] + frame.positions,
+        )
+
+    def _nearest_ball_timestamp(self, timestamp: np.datetime64) -> np.datetime64 | None:
+        if self.ball_unique_timestamps.size == 0:
+            return None
+        pos = np.searchsorted(self.ball_unique_timestamps, timestamp)
+        candidates = []
+        if pos < self.ball_unique_timestamps.size:
+            candidates.append(self.ball_unique_timestamps[pos])
+        if pos > 0:
+            candidates.append(self.ball_unique_timestamps[pos - 1])
+        if not candidates:
+            return None
+        nearest = min(candidates, key=lambda candidate: abs(candidate - timestamp))
+        if abs(nearest - timestamp) <= self.timestamp_tolerance:
+            return nearest
+        return None
+
+
+def _compute_deltas(frames: list[H5Frame], *, missing_value: float) -> list[H5Frame]:
+    previous = {}
+    output = []
+    for frame in frames:
+        features = frame.features.copy()
+        for idx, entity_id in enumerate(frame.entity_ids):
+            xyz = features[idx, 0:3]
+            valid = not np.any(np.isclose(xyz[:2], missing_value))
+            if valid and entity_id in previous:
+                delta = xyz - previous[entity_id]
+                if np.isclose(xyz[2], missing_value) or np.isclose(previous[entity_id][2], missing_value):
+                    delta[2] = 0.0
+                features[idx, 6:9] = delta
+            if valid:
+                previous[entity_id] = xyz.copy()
+        output.append(H5Frame(frame.timestamp, features, frame.entity_ids, frame.positions))
+    return output
+
+
+def normalize_h5_features(
+    features: np.ndarray,
+    *,
+    pitch_half_length: float = 85.0,
+    pitch_half_width: float = 50.0,
+    max_height: float = 30.0,
+    max_displacement: float = 110.0,
+    missing_value: float = MISSING_VALUE,
+) -> np.ndarray:
+    """Normalize H5 XYZ graph features without mutating the input."""
+    out = features.copy()
+    valid_mask = out[:, :, 0] != missing_value
+    out[valid_mask, 0] /= pitch_half_length
+    out[valid_mask, 1] /= pitch_half_width
+    out[valid_mask, 2] /= max_height
+    out[valid_mask, 6:9] /= max_displacement
+    for ch in (0, 1, 2, 6, 7, 8):
+        out[~valid_mask, ch] = MISSING_VALUE_NORMALIZED
+    return out

--- a/opensportslib/models/base/rule_based.py
+++ b/opensportslib/models/base/rule_based.py
@@ -1,0 +1,579 @@
+"""Rule-based localization models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from opensportslib.core.config.accessors import (
+    get_component_params_by_kind,
+    get_data_params,
+)
+from opensportslib.datasets.utils.h5_tracking import parse_utc
+
+
+DEFAULT_HEADER_RULE_PARAMS = {
+    "label": "header",
+    "head_name": "action",
+    "distance_threshold_m": 0.5,
+    "min_confidence": 0.5,
+    "confidence_mode": "linear_inverse_distance",
+    "confidence_power": 1.0,
+    "nms_window_ms": 1000,
+    "nms_scope": "sample",
+    "ball_tolerance_ms": 60,
+    "chunk_size": 100000,
+    "head_joints": ["nose", "neck", "l_eye", "r_eye", "l_ear", "r_ear"],
+    "required_input_type": "player_joints_h5",
+    "ball_path_field": "ball_path",
+    "timestamp_field": "timestamp_utc",
+    "output_task": "action_spotting",
+    "include_diagnostics": True,
+    "created_by": "h5_header_distance_rule",
+    "position_ms_origin": "joint_h5_start",
+    "metadata_start_field": "start_utc",
+    "metadata_end_field": "end_utc",
+    "ball_coordinate_fields": ["x", "y", "z"],
+    "joint_coordinate_suffixes": ["x", "y", "z"],
+    "identity_fields": ["player_id", "jersey_number", "team_id", "is_home"],
+    "invalid_coordinate_values": [-200.0],
+    "sideline_filter_enabled": True,
+    "pitch_half_width_m": 50.0,
+    "sideline_exclusion_m": 1.0,
+    "sideline_reference": "ball_y",
+    "trajectory_filter_enabled": True,
+    "trajectory_change_mode": "either_angle_or_speed",
+    "trajectory_pre_window_ms": 200,
+    "trajectory_post_window_ms": 200,
+    "trajectory_min_angle_deg": 25.0,
+    "trajectory_min_speed_delta_ratio": 0.25,
+    "trajectory_min_vector_norm_m": 0.05,
+    "trajectory_use_xy_only": False,
+    "confidence_output_key": "confidence_score",
+}
+
+
+HEADER_RULE_VARIANTS = {
+    "h5_header_distance": {
+        "trajectory_filter_enabled": False,
+        "trajectory_change_mode": "either_angle_or_speed",
+        "created_by": "h5_header_distance_rule",
+    },
+    "h5_header_distance_speed": {
+        "trajectory_filter_enabled": True,
+        "trajectory_change_mode": "speed",
+        "created_by": "h5_header_distance_speed_rule",
+    },
+    "h5_header_distance_angle": {
+        "trajectory_filter_enabled": True,
+        "trajectory_change_mode": "angle",
+        "created_by": "h5_header_distance_angle_rule",
+    },
+    "h5_header_distance_speed_angle": {
+        "trajectory_filter_enabled": True,
+        "trajectory_change_mode": "both_angle_and_speed",
+        "created_by": "h5_header_distance_speed_angle_rule",
+    },
+}
+
+
+@dataclass
+class _Candidate:
+    timestamp: np.datetime64
+    position_ms: int
+    confidence: float
+    distance_m: float
+    joint: str
+    player_id: str | None
+    ball_timestamp: np.datetime64
+    ball_index: int
+    ball_xyz: np.ndarray
+    ball_y: float
+    sideline_distance_m: float
+    trajectory: dict
+
+
+class H5OSLJsonSpottingDataset:
+    """Lightweight OSL JSON manifest wrapper for rule-based H5 spotting."""
+
+    rule_based_no_dataloader = True
+
+    def __init__(self, annotation_path, source_path=None):
+        self.annotation_path = str(annotation_path)
+        self.source_path = str(source_path or os.path.dirname(os.path.abspath(self.annotation_path)))
+        with open(self.annotation_path, "r", encoding="utf-8") as f:
+            self.payload = json.load(f)
+        self.samples = list(self.payload.get("data", []))
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        return self.samples[idx]
+
+
+class H5HeaderSpotter:
+    """Rule-based H5 header spotter driven entirely by config parameters."""
+
+    variant_name = "h5_header_distance"
+
+    def __init__(self, config):
+        rule_params = get_component_params_by_kind(config, "algorithm")
+        if not rule_params:
+            rule_params = get_data_params(config)
+        params = dict(DEFAULT_HEADER_RULE_PARAMS)
+        params.update(rule_params or {})
+        configured_variant = params.pop("type", None) or self.variant_name
+        params.update(HEADER_RULE_VARIANTS.get(configured_variant, {}))
+        params["model_variant"] = configured_variant
+        self.params = params
+
+    def predict(self, dataset):
+        data = []
+        for sample in getattr(dataset, "samples", []):
+            events = self._predict_sample(sample, dataset.source_path)
+            data.append(
+                {
+                    "id": sample.get("id"),
+                    "inputs": sample.get("inputs", []),
+                    "events": events,
+                }
+            )
+
+        label = self.params["label"]
+        head_name = self.params["head_name"]
+        return {
+            "version": "2.0",
+            "date": datetime.now().strftime("%Y-%m-%d"),
+            "task": self.params["output_task"],
+            "metadata": {
+                "type": "predictions",
+                "created_by": self.params["created_by"],
+            },
+            "labels": {
+                head_name: {
+                    "type": "single_label",
+                    "labels": [label],
+                }
+            },
+            "data": data,
+        }
+
+    def _predict_sample(self, sample, source_path):
+        inputs = sample.get("inputs", []) or []
+        candidates = []
+        for input_obj in inputs:
+            if input_obj.get("type") != self.params["required_input_type"]:
+                continue
+            ball_path = input_obj.get(self.params["ball_path_field"])
+            if not ball_path:
+                continue
+            candidates.extend(
+                self._scan_joint_input(
+                    joint_path=self._resolve_path(source_path, input_obj["path"]),
+                    ball_path=self._resolve_path(source_path, ball_path),
+                    sample_metadata=sample.get("metadata", {}) or {},
+                )
+            )
+
+        filtered = [
+            candidate
+            for candidate in candidates
+            if candidate.confidence > float(self.params["min_confidence"])
+        ]
+        return [self._candidate_to_event(candidate) for candidate in self._nms(filtered)]
+
+    @staticmethod
+    def _resolve_path(source_path, path):
+        if os.path.isabs(path):
+            return path
+        return os.path.join(source_path, path)
+
+    def _scan_joint_input(self, joint_path, ball_path, sample_metadata):
+        ball = self._load_ball(ball_path)
+        if ball["timestamps"].size == 0:
+            return []
+
+        start_utc = sample_metadata.get(self.params["metadata_start_field"])
+        end_utc = sample_metadata.get(self.params["metadata_end_field"])
+        start_ts = parse_utc(start_utc) if start_utc else None
+        end_ts = parse_utc(end_utc) if end_utc else None
+
+        candidates = []
+        timestamp_field = self.params["timestamp_field"]
+        chunk_size = int(self.params["chunk_size"])
+        with h5py.File(joint_path, "r") as f:
+            if timestamp_field not in f:
+                raise ValueError(f"H5 file is missing required dataset '{timestamp_field}': {joint_path}")
+            num_rows = len(f[timestamp_field])
+            base_ts = self._min_timestamp(f[timestamp_field], chunk_size)
+            for chunk_start in range(0, num_rows, chunk_size):
+                chunk_end = min(chunk_start + chunk_size, num_rows)
+                row_slice = slice(chunk_start, chunk_end)
+                timestamps = np.asarray(
+                    [parse_utc(value) for value in f[timestamp_field][row_slice]],
+                    dtype="datetime64[us]",
+                )
+                mask = np.ones(timestamps.shape[0], dtype=bool)
+                if start_ts is not None:
+                    mask &= timestamps >= start_ts
+                if end_ts is not None:
+                    mask &= timestamps <= end_ts
+                if not np.any(mask):
+                    continue
+
+                chunk_candidates = self._scan_chunk(
+                    f=f,
+                    row_slice=row_slice,
+                    timestamps=timestamps,
+                    mask=mask,
+                    base_ts=base_ts,
+                    ball=ball,
+                )
+                candidates.extend(chunk_candidates)
+        return candidates
+
+    @staticmethod
+    def _min_timestamp(timestamp_dataset, chunk_size):
+        min_ts = None
+        num_rows = len(timestamp_dataset)
+        for chunk_start in range(0, num_rows, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, num_rows)
+            timestamps = [
+                parse_utc(value)
+                for value in timestamp_dataset[chunk_start:chunk_end]
+            ]
+            if not timestamps:
+                continue
+            chunk_min = min(timestamps)
+            if min_ts is None or chunk_min < min_ts:
+                min_ts = chunk_min
+        if min_ts is None:
+            raise ValueError("Joint H5 input has no timestamps.")
+        return min_ts
+
+    def _scan_chunk(self, *, f, row_slice, timestamps, mask, base_ts, ball):
+        masked_timestamps = timestamps[mask]
+        nearest_indices, nearest_valid = self._nearest_ball_indices(masked_timestamps, ball)
+        if not np.any(nearest_valid):
+            return []
+
+        all_rows = np.arange(row_slice.start, row_slice.stop)
+        selected_rows = all_rows[mask]
+        identity = self._read_identity(f, selected_rows)
+        candidates = []
+        for joint in self.params["head_joints"]:
+            columns = [f"{joint}_{suffix}" for suffix in self.params["joint_coordinate_suffixes"]]
+            if not all(column in f for column in columns):
+                continue
+            coords = np.stack([f[column][selected_rows] for column in columns], axis=1).astype(float)
+            valid_coords = self._valid_coordinates(coords)
+            valid = nearest_valid & valid_coords
+            if not np.any(valid):
+                continue
+
+            ball_xyz = ball["xyz"][nearest_indices[valid]]
+            distances = np.linalg.norm(coords[valid] - ball_xyz, axis=1)
+            within = distances < float(self.params["distance_threshold_m"])
+            if not np.any(within):
+                continue
+
+            valid_positions = np.flatnonzero(valid)[within]
+            for local_pos, distance in zip(valid_positions, distances[within]):
+                confidence = self._confidence(float(distance))
+                timestamp = masked_timestamps[local_pos]
+                ball_index = int(nearest_indices[local_pos])
+                ball_timestamp = ball["timestamps"][ball_index]
+                ball_xyz_at_contact = ball["xyz"][ball_index]
+                if not self._passes_sideline_filter(ball_xyz_at_contact):
+                    continue
+                trajectory = self._trajectory_diagnostics(ball, ball_index)
+                if self.params["trajectory_filter_enabled"] and not trajectory["trajectory_passed"]:
+                    continue
+                candidates.append(
+                    _Candidate(
+                        timestamp=timestamp,
+                        position_ms=self._position_ms(timestamp, base_ts),
+                        confidence=confidence,
+                        distance_m=float(distance),
+                        joint=joint,
+                        player_id=identity[local_pos],
+                        ball_timestamp=ball_timestamp,
+                        ball_index=ball_index,
+                        ball_xyz=ball_xyz_at_contact,
+                        ball_y=float(ball_xyz_at_contact[1]),
+                        sideline_distance_m=self._sideline_distance(ball_xyz_at_contact),
+                        trajectory=trajectory,
+                    )
+                )
+        return candidates
+
+    def _load_ball(self, ball_path):
+        timestamp_field = self.params["timestamp_field"]
+        coord_fields = self.params["ball_coordinate_fields"]
+        with h5py.File(ball_path, "r") as f:
+            if timestamp_field not in f:
+                raise ValueError(f"H5 file is missing required dataset '{timestamp_field}': {ball_path}")
+            if not all(field in f for field in coord_fields):
+                missing = [field for field in coord_fields if field not in f]
+                raise ValueError(f"Ball H5 is missing coordinate datasets {missing}: {ball_path}")
+            timestamps = np.asarray(
+                [parse_utc(value) for value in f[timestamp_field][:]],
+                dtype="datetime64[us]",
+            )
+            xyz = np.stack([f[field][:] for field in coord_fields], axis=1).astype(float)
+
+        valid = self._valid_coordinates(xyz)
+        timestamps = timestamps[valid]
+        xyz = xyz[valid]
+        order = np.argsort(timestamps)
+        return {"timestamps": timestamps[order], "xyz": xyz[order]}
+
+    def _nearest_ball_indices(self, timestamps, ball):
+        ball_ts = ball["timestamps"]
+        positions = np.searchsorted(ball_ts, timestamps)
+        nearest = np.zeros(timestamps.shape[0], dtype=np.int64)
+        valid = np.zeros(timestamps.shape[0], dtype=bool)
+        tolerance = np.timedelta64(int(float(self.params["ball_tolerance_ms"]) * 1000), "us")
+
+        for idx, pos in enumerate(positions):
+            choices = []
+            if pos < ball_ts.size:
+                choices.append(pos)
+            if pos > 0:
+                choices.append(pos - 1)
+            if not choices:
+                continue
+            best = min(choices, key=lambda choice: abs(ball_ts[choice] - timestamps[idx]))
+            if abs(ball_ts[best] - timestamps[idx]) <= tolerance:
+                nearest[idx] = best
+                valid[idx] = True
+        return nearest, valid
+
+    def _valid_coordinates(self, coords):
+        valid = np.isfinite(coords).all(axis=1)
+        for invalid_value in self.params.get("invalid_coordinate_values", []):
+            valid &= ~np.isclose(coords, float(invalid_value)).any(axis=1)
+        return valid
+
+    def _read_identity(self, f, rows):
+        fields = [field for field in self.params["identity_fields"] if field in f]
+        if not fields:
+            return [None] * len(rows)
+
+        values_by_field = {field: f[field][rows] for field in fields}
+        identities = []
+        for idx in range(len(rows)):
+            parts = []
+            for field in fields:
+                value = values_by_field[field][idx]
+                if isinstance(value, (bytes, np.bytes_)):
+                    value = value.decode("utf-8")
+                value = str(value)
+                if value:
+                    parts.append(f"{field}={value}")
+            identities.append(";".join(parts) if parts else None)
+        return identities
+
+    def _confidence(self, distance):
+        threshold = float(self.params["distance_threshold_m"])
+        if self.params["confidence_mode"] != "linear_inverse_distance":
+            raise ValueError(f"Unsupported confidence_mode: {self.params['confidence_mode']}")
+        raw = 1.0 - (distance / threshold)
+        confidence = max(0.0, min(1.0, raw))
+        return confidence ** float(self.params["confidence_power"])
+
+    def _passes_sideline_filter(self, ball_xyz):
+        if not self.params["sideline_filter_enabled"]:
+            return True
+        if self.params["sideline_reference"] != "ball_y":
+            raise ValueError(f"Unsupported sideline_reference: {self.params['sideline_reference']}")
+        return self._sideline_distance(ball_xyz) > float(self.params["sideline_exclusion_m"])
+
+    def _sideline_distance(self, ball_xyz):
+        return float(self.params["pitch_half_width_m"]) - abs(float(ball_xyz[1]))
+
+    def _trajectory_diagnostics(self, ball, ball_index):
+        default = {
+            "trajectory_angle_deg": None,
+            "trajectory_speed_before_mps": None,
+            "trajectory_speed_after_mps": None,
+            "trajectory_speed_delta_ratio": None,
+            "trajectory_passed": not self.params["trajectory_filter_enabled"],
+        }
+        pre_idx = self._window_endpoint_index(
+            ball,
+            ball_index,
+            direction="pre",
+            window_ms=float(self.params["trajectory_pre_window_ms"]),
+        )
+        post_idx = self._window_endpoint_index(
+            ball,
+            ball_index,
+            direction="post",
+            window_ms=float(self.params["trajectory_post_window_ms"]),
+        )
+        if pre_idx is None or post_idx is None:
+            return default
+
+        contact_xyz = ball["xyz"][ball_index]
+        pre_vec = contact_xyz - ball["xyz"][pre_idx]
+        post_vec = ball["xyz"][post_idx] - contact_xyz
+        if self.params["trajectory_use_xy_only"]:
+            pre_vec = pre_vec[:2]
+            post_vec = post_vec[:2]
+
+        pre_norm = float(np.linalg.norm(pre_vec))
+        post_norm = float(np.linalg.norm(post_vec))
+        min_norm = float(self.params["trajectory_min_vector_norm_m"])
+        if pre_norm < min_norm or post_norm < min_norm:
+            return default
+
+        cos_angle = float(np.dot(pre_vec, post_vec) / (pre_norm * post_norm))
+        cos_angle = max(-1.0, min(1.0, cos_angle))
+        angle_deg = float(np.degrees(np.arccos(cos_angle)))
+        pre_dt = self._elapsed_seconds(ball["timestamps"][pre_idx], ball["timestamps"][ball_index])
+        post_dt = self._elapsed_seconds(ball["timestamps"][ball_index], ball["timestamps"][post_idx])
+        if pre_dt <= 0 or post_dt <= 0:
+            return default
+
+        speed_before = pre_norm / pre_dt
+        speed_after = post_norm / post_dt
+        denom = max(speed_before, 1e-9)
+        speed_delta_ratio = abs(speed_after - speed_before) / denom
+
+        angle_passed = angle_deg >= float(self.params["trajectory_min_angle_deg"])
+        speed_passed = speed_delta_ratio >= float(self.params["trajectory_min_speed_delta_ratio"])
+        mode = self.params["trajectory_change_mode"]
+        if mode == "either_angle_or_speed":
+            trajectory_passed = angle_passed or speed_passed
+        elif mode == "angle":
+            trajectory_passed = angle_passed
+        elif mode == "speed":
+            trajectory_passed = speed_passed
+        elif mode == "both_angle_and_speed":
+            trajectory_passed = angle_passed and speed_passed
+        else:
+            raise ValueError(f"Unsupported trajectory_change_mode: {mode}")
+
+        return {
+            "trajectory_angle_deg": angle_deg,
+            "trajectory_speed_before_mps": speed_before,
+            "trajectory_speed_after_mps": speed_after,
+            "trajectory_speed_delta_ratio": speed_delta_ratio,
+            "trajectory_passed": bool(trajectory_passed),
+        }
+
+    @staticmethod
+    def _elapsed_seconds(start, end):
+        delta_us = (end - start).astype("timedelta64[us]").astype(np.int64)
+        return float(delta_us) / 1_000_000.0
+
+    @staticmethod
+    def _window_endpoint_index(ball, ball_index, *, direction, window_ms):
+        timestamps = ball["timestamps"]
+        contact_ts = timestamps[ball_index]
+        window = np.timedelta64(int(window_ms * 1000), "us")
+        if direction == "pre":
+            start_ts = contact_ts - window
+            left = int(np.searchsorted(timestamps, start_ts, side="left"))
+            if left >= ball_index:
+                return None
+            return left
+        if direction == "post":
+            end_ts = contact_ts + window
+            right = int(np.searchsorted(timestamps, end_ts, side="right")) - 1
+            if right <= ball_index:
+                return None
+            return right
+        raise ValueError(f"Unsupported trajectory endpoint direction: {direction}")
+
+    @staticmethod
+    def _position_ms(timestamp, base_ts):
+        delta_us = (timestamp - base_ts).astype("timedelta64[us]").astype(np.int64)
+        return int(round(delta_us / 1000.0))
+
+    def _nms(self, candidates):
+        if self.params["nms_scope"] != "sample":
+            raise ValueError(f"Unsupported nms_scope: {self.params['nms_scope']}")
+        window_us = int(float(self.params["nms_window_ms"]) * 1000)
+        selected = []
+        for candidate in sorted(candidates, key=lambda item: item.confidence, reverse=True):
+            timestamp_us = candidate.timestamp.astype("datetime64[us]").astype(np.int64)
+            duplicate = False
+            for kept in selected:
+                kept_us = kept.timestamp.astype("datetime64[us]").astype(np.int64)
+                if abs(timestamp_us - kept_us) <= window_us:
+                    duplicate = True
+                    break
+            if not duplicate:
+                selected.append(candidate)
+        return sorted(selected, key=lambda item: item.timestamp)
+
+    def _candidate_to_event(self, candidate):
+        event = {
+            "head": self.params["head_name"],
+            "label": self.params["label"],
+            "position_ms": candidate.position_ms,
+            "timestamp_utc": str(candidate.timestamp).replace("T", " "),
+            self.params["confidence_output_key"]: float(candidate.confidence),
+        }
+        if self.params["include_diagnostics"]:
+            event["metadata"] = {
+                "distance_m": candidate.distance_m,
+                "joint": candidate.joint,
+                "player_id": candidate.player_id,
+                "ball_timestamp_utc": str(candidate.ball_timestamp).replace("T", " "),
+                "ball_y": candidate.ball_y,
+                "sideline_distance_m": candidate.sideline_distance_m,
+                **candidate.trajectory,
+            }
+        return event
+
+
+class H5HeaderDistanceSpotter(H5HeaderSpotter):
+    """Header spotting from head-ball distance only."""
+
+    variant_name = "h5_header_distance"
+
+
+class H5HeaderDistanceSpeedSpotter(H5HeaderSpotter):
+    """Header spotting from head-ball distance plus ball speed change."""
+
+    variant_name = "h5_header_distance_speed"
+
+
+class H5HeaderDistanceAngleSpotter(H5HeaderSpotter):
+    """Header spotting from head-ball distance plus ball trajectory angle change."""
+
+    variant_name = "h5_header_distance_angle"
+
+
+class H5HeaderDistanceSpeedAngleSpotter(H5HeaderSpotter):
+    """Header spotting from distance, speed change, and angle change."""
+
+    variant_name = "h5_header_distance_speed_angle"
+
+
+def build_rule_based_model(config):
+    rule_params = get_component_params_by_kind(config, "algorithm")
+    variant = (rule_params or {}).get("type", "h5_header_distance")
+    registry = {
+        "h5_header_distance": H5HeaderDistanceSpotter,
+        "h5_header_distance_speed": H5HeaderDistanceSpeedSpotter,
+        "h5_header_distance_angle": H5HeaderDistanceAngleSpotter,
+        "h5_header_distance_speed_angle": H5HeaderDistanceSpeedAngleSpotter,
+    }
+    try:
+        return registry[variant](config)
+    except KeyError as exc:
+        raise ValueError(
+            f"Unsupported rule-based model: {variant}. "
+            f"Expected one of: {', '.join(sorted(registry))}."
+        ) from exc

--- a/opensportslib/models/builder.py
+++ b/opensportslib/models/builder.py
@@ -61,14 +61,19 @@ def build_model_canonical(config, device):
         from opensportslib.models.base.contextaware import LiteContextAwareModel
         from opensportslib.models.base.learnablepooling import LiteLearnablePoolingModel
 
-        backbone = _component_cfg(config, "encoder")
-        head = _component_cfg(config, "head")
         model_weights = (
             get_model_load(config).get("checkpoint_path")
             or get_component_load_by_kind(config, "encoder").get("weights_path")
         )
         runner = get_runner_type(config)
         normalized_family = str(model_family or "").strip().lower()
+
+        if normalized_family == "rulebased":
+            from opensportslib.models.base.rule_based import build_rule_based_model
+            return build_rule_based_model(config)
+
+        backbone = _component_cfg(config, "encoder")
+        head = _component_cfg(config, "head")
 
         if normalized_family == "learnablepooling":
             neck = _component_cfg(config, "adapter")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.0.dev4"
 description = "OpenSportsLib is the professional library, designed for advanced video understanding in sports. It provides state-of-the-art tools for action recognition, spotting, retrieval, and captioning, making it ideal for researchers, analysts, and developers working with sports video data."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [ "SoccerNet", "av", "decord; platform_system != 'Darwin' and platform_machine != 'arm64' and platform_machine != 'aarch64'", "evaluate", "scikit-learn", "torch", "torchvision", "transformers==4.57.3", "tokenizers==0.22.1", "accelerate", "wandb", "opencv-python", "omegaconf", "timm", "seaborn", "tabulate", "pytorch-lightning", "pandas", "pyarrow", "huggingface_hub", "easydict",]
+dependencies = [ "SoccerNet", "av", "decord; platform_system != 'Darwin' and platform_machine != 'arm64' and platform_machine != 'aarch64'", "evaluate", "scikit-learn", "torch", "torchvision", "transformers==4.57.3", "tokenizers==0.22.1", "accelerate", "wandb", "opencv-python", "omegaconf", "timm", "seaborn", "tabulate", "pytorch-lightning", "pandas", "pyarrow", "h5py", "huggingface_hub", "easydict",]
 [[project.authors]]
 name = "Jeet Vora"
 

--- a/scripts/run_h5_header_rule_inference.py
+++ b/scripts/run_h5_header_rule_inference.py
@@ -1,0 +1,66 @@
+"""Run YAML-configured H5 header spotting and save OSL JSON predictions."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from opensportslib.apis import LocalizationModel
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT_DIR = Path("/Users/giancos/git/VideoAnnotationTool/test_data")
+
+METHOD_CONFIGS = {
+    "distance": REPO_ROOT / "opensportslib/configs/localization/h5_header_distance.yaml",
+    "distance_speed": REPO_ROOT / "opensportslib/configs/localization/h5_header_distance_speed.yaml",
+    "distance_angle": REPO_ROOT / "opensportslib/configs/localization/h5_header_distance_angle.yaml",
+    "distance_speed_angle": REPO_ROOT
+    / "opensportslib/configs/localization/h5_header_distance_speed_angle.yaml",
+}
+
+
+def run_method(method: str, config_path: Path, output_dir: Path) -> Path:
+    api = LocalizationModel(config=str(config_path))
+    predictions = api.infer(use_wandb=False)
+    output_path = output_dir / f"h5_header_predictions_{method}.json"
+    return Path(api.save_predictions(str(output_path), predictions))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run rule-based H5 header spotting and save OSL JSON predictions. "
+            "By default, all four configured methods are run."
+        )
+    )
+    parser.add_argument(
+        "--method",
+        choices=["all", *METHOD_CONFIGS.keys()],
+        default="all",
+        help="Header spotting method to run.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory where prediction JSON files will be saved.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    os.environ.setdefault("RUN_ID", "h5-header-rule")
+    output_dir = args.output_dir.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    methods = METHOD_CONFIGS.keys() if args.method == "all" else [args.method]
+    for method in methods:
+        saved_path = run_method(method, METHOD_CONFIGS[method], output_dir)
+        print(f"{method}: {saved_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_h5_header_rule_inference.py
+++ b/scripts/run_h5_header_rule_inference.py
@@ -10,8 +10,7 @@ from opensportslib.apis import LocalizationModel
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_OUTPUT_DIR = Path("/Users/giancos/git/VideoAnnotationTool/test_data")
-
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "h5_header_rule"
 METHOD_CONFIGS = {
     "distance": REPO_ROOT / "opensportslib/configs/localization/h5_header_distance.yaml",
     "distance_speed": REPO_ROOT / "opensportslib/configs/localization/h5_header_distance_speed.yaml",

--- a/tests/test_h5_header_rule_spotter.py
+++ b/tests/test_h5_header_rule_spotter.py
@@ -1,0 +1,540 @@
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from omegaconf import OmegaConf
+
+from opensportslib.datasets.localization_dataset import LocalizationDataset
+from opensportslib.models.base.rule_based import (
+    H5HeaderDistanceAngleSpotter,
+    H5HeaderDistanceSpeedAngleSpotter,
+    H5HeaderDistanceSpeedSpotter,
+    H5HeaderDistanceSpotter,
+    H5HeaderSpotter,
+)
+from opensportslib.models.builder import build_model
+from opensportslib.core.trainer.localization_trainer import build_inferer
+from opensportslib.apis.localization import LocalizationModel
+
+
+def _bytes(values):
+    return np.asarray([value.encode("utf-8") for value in values], dtype="S26")
+
+
+def _write_ball(path: Path):
+    with h5py.File(path, "w") as f:
+        f.create_dataset(
+            "timestamp_utc",
+            data=_bytes([
+                "2026-01-01 00:00:01.000000",
+                "2026-01-01 00:00:00.000000",
+                "2026-01-01 00:00:00.020000",
+            ]),
+        )
+        f.create_dataset("x", data=np.asarray([10.0, 0.0, 0.05]))
+        f.create_dataset("y", data=np.asarray([10.0, 0.0, 0.0]))
+        f.create_dataset("z", data=np.asarray([10.0, 0.0, 0.0]))
+
+
+def _write_ball_from_rows(path: Path, rows):
+    with h5py.File(path, "w") as f:
+        f.create_dataset("timestamp_utc", data=_bytes([row[0] for row in rows]))
+        f.create_dataset("x", data=np.asarray([row[1] for row in rows], dtype=float))
+        f.create_dataset("y", data=np.asarray([row[2] for row in rows], dtype=float))
+        f.create_dataset("z", data=np.asarray([row[3] for row in rows], dtype=float))
+
+
+def _write_joints(path: Path):
+    with h5py.File(path, "w") as f:
+        f.create_dataset(
+            "timestamp_utc",
+            data=_bytes([
+                "2026-01-01 00:00:00.000000",
+                "2026-01-01 00:00:00.020000",
+                "2026-01-01 00:00:02.000000",
+            ]),
+        )
+        f.create_dataset("player_id", data=_bytes(["p1", "p1", "p1"]))
+        f.create_dataset("jersey_number", data=_bytes(["9", "9", "9"]))
+        f.create_dataset("team_id", data=_bytes(["home", "home", "home"]))
+        f.create_dataset("is_home", data=np.asarray([1, 1, 1]))
+        f.create_dataset("nose_x", data=np.asarray([0.0, 0.10, 0.30]))
+        f.create_dataset("nose_y", data=np.asarray([0.0, 0.0, 0.0]))
+        f.create_dataset("nose_z", data=np.asarray([0.0, 0.0, 0.0]))
+        f.create_dataset("neck_x", data=np.asarray([2.0, 2.0, 2.0]))
+        f.create_dataset("neck_y", data=np.asarray([2.0, 2.0, 2.0]))
+        f.create_dataset("neck_z", data=np.asarray([2.0, 2.0, 2.0]))
+
+
+def _write_unsorted_joints(path: Path):
+    with h5py.File(path, "w") as f:
+        f.create_dataset(
+            "timestamp_utc",
+            data=_bytes([
+                "2026-01-01 00:00:02.000000",
+                "2026-01-01 00:00:00.000000",
+                "2026-01-01 00:00:00.020000",
+            ]),
+        )
+        f.create_dataset("player_id", data=_bytes(["p1", "p1", "p1"]))
+        f.create_dataset("jersey_number", data=_bytes(["9", "9", "9"]))
+        f.create_dataset("team_id", data=_bytes(["home", "home", "home"]))
+        f.create_dataset("is_home", data=np.asarray([1, 1, 1]))
+        f.create_dataset("nose_x", data=np.asarray([0.30, 0.0, 0.10]))
+        f.create_dataset("nose_y", data=np.asarray([0.0, 0.0, 0.0]))
+        f.create_dataset("nose_z", data=np.asarray([0.0, 0.0, 0.0]))
+        f.create_dataset("neck_x", data=np.asarray([2.0, 2.0, 2.0]))
+        f.create_dataset("neck_y", data=np.asarray([2.0, 2.0, 2.0]))
+        f.create_dataset("neck_z", data=np.asarray([2.0, 2.0, 2.0]))
+
+
+def _write_manifest(path: Path, input_type="player_joints_h5", metadata=None):
+    payload = {
+        "version": "2.0",
+        "modalities": [input_type],
+        "labels": {"action": {"type": "single_label", "labels": ["header"]}},
+        "data": [
+            {
+                "id": "sample",
+                "inputs": [
+                    {
+                        "type": input_type,
+                        "path": "joints.h5",
+                        "ball_path": "ball.h5",
+                    }
+                ],
+                "metadata": metadata or {},
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _config(
+    root: Path,
+    manifest: Path,
+    *,
+    include_diagnostics=True,
+    input_type="player_joints_h5",
+    rule_overrides=None,
+    rule_name="h5_header_distance",
+):
+    rule_params = {
+        "label": "header",
+        "head_name": "action",
+        "distance_threshold_m": 0.5,
+        "min_confidence": 0.5,
+        "confidence_mode": "linear_inverse_distance",
+        "confidence_power": 1.0,
+        "nms_window_ms": 1000,
+        "nms_scope": "sample",
+        "ball_tolerance_ms": 60,
+        "chunk_size": 2,
+        "head_joints": ["nose", "neck"],
+        "required_input_type": "player_joints_h5",
+        "ball_path_field": "ball_path",
+        "timestamp_field": "timestamp_utc",
+        "output_task": "action_spotting",
+        "include_diagnostics": include_diagnostics,
+        "sideline_filter_enabled": False,
+        "pitch_half_width_m": 50.0,
+        "sideline_exclusion_m": 1.0,
+        "sideline_reference": "ball_y",
+        "trajectory_filter_enabled": False,
+        "trajectory_change_mode": "either_angle_or_speed",
+        "trajectory_pre_window_ms": 200,
+        "trajectory_post_window_ms": 200,
+        "trajectory_min_angle_deg": 25.0,
+        "trajectory_min_speed_delta_ratio": 0.25,
+        "trajectory_min_vector_norm_m": 0.05,
+        "trajectory_use_xy_only": False,
+        "confidence_output_key": "confidence_score",
+    }
+    if rule_overrides:
+        rule_params.update(rule_overrides)
+    return OmegaConf.create(
+        {
+            "TASK": "localization",
+            "VERSION": 2,
+            "SYSTEM": {"device": "cpu", "gpu": {"count": 0}, "paths": {"work_dir": str(root)}},
+            "DATA": {
+                "common": {
+                    "dataset_name": "h5_headers",
+                    "classes": ["header"],
+                    "splits": {
+                        "test": {
+                            "type": "H5OSLJsonSpotting",
+                            "annotation_path": str(manifest),
+                            "source_path": str(root),
+                            "dataloader": {
+                                "batch_size": 1,
+                                "shuffle": False,
+                                "num_workers": 0,
+                                "pin_memory": False,
+                            },
+                        }
+                    },
+                },
+                "inputs": {
+                    "tracking": {
+                        "modality": input_type,
+                        "representation": "raw",
+                        "source": {"format": "h5"},
+                        "sampling": {},
+                        "transform": {},
+                        "augmentations": {},
+                        "params": {},
+                    }
+                },
+            },
+            "MODEL": {
+                "metadata": {
+                    "family": "RuleBased",
+                    "runner": {"type": "runner_h5_header_rule"},
+                },
+                "components": {
+                    "rule": {
+                        "kind": "algorithm",
+                        "source": {
+                            "provider": "opensportslib",
+                            "registry": "rule_based",
+                            "name": rule_name,
+                        },
+                        "params": rule_params,
+                    }
+                },
+                "topology": [],
+            },
+            "TRAIN": {
+                "trainer": {"type": "trainer_rule_based"},
+                "execution": {"enabled": False},
+            },
+        }
+    )
+
+
+def test_rule_based_yaml_route_builds_model_and_inferer(tmp_path):
+    _write_ball(tmp_path / "ball.h5")
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(manifest)
+    cfg = _config(tmp_path, manifest)
+
+    model = build_model(cfg, device=None)
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    dataloader = dataset_obj.building_dataloader(dataset, dataset_obj.cfg.dataloader, gpu=0, dali=False)
+    predictions = build_inferer(cfg, model).infer(cfg, dataset, dataloader)
+
+    assert isinstance(model, H5HeaderSpotter)
+    assert dataloader is None
+    assert predictions["task"] == "action_spotting"
+    assert predictions["labels"]["action"]["labels"] == ["header"]
+
+
+def test_rule_based_model_variants_are_selected_from_yaml_name(tmp_path):
+    manifest = tmp_path / "h5.json"
+    _write_manifest(manifest)
+
+    variants = {
+        "h5_header_distance": (H5HeaderDistanceSpotter, False, "either_angle_or_speed"),
+        "h5_header_distance_speed": (H5HeaderDistanceSpeedSpotter, True, "speed"),
+        "h5_header_distance_angle": (H5HeaderDistanceAngleSpotter, True, "angle"),
+        "h5_header_distance_speed_angle": (
+            H5HeaderDistanceSpeedAngleSpotter,
+            True,
+            "both_angle_and_speed",
+        ),
+    }
+    for rule_name, (expected_cls, trajectory_enabled, trajectory_mode) in variants.items():
+        model = build_model(_config(tmp_path, manifest, rule_name=rule_name), device=None)
+        assert isinstance(model, expected_cls)
+        assert model.params["trajectory_filter_enabled"] is trajectory_enabled
+        assert model.params["trajectory_change_mode"] == trajectory_mode
+
+
+def test_header_rule_filters_confidence_applies_nms_and_exports_osl_json(tmp_path):
+    _write_ball(tmp_path / "ball.h5")
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(manifest)
+    cfg = _config(tmp_path, manifest)
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    predictions = H5HeaderSpotter(cfg).predict(dataset)
+
+    events = predictions["data"][0]["events"]
+    assert len(events) == 1
+    assert events[0]["label"] == "header"
+    assert events[0]["confidence_score"] == 1.0
+    assert "confidence" not in events[0]
+    assert events[0]["position_ms"] == 0
+    assert "metadata" in events[0]
+    assert events[0]["metadata"]["joint"] == "nose"
+
+
+def test_header_rule_diagnostics_can_be_disabled(tmp_path):
+    _write_ball(tmp_path / "ball.h5")
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(manifest)
+    cfg = _config(tmp_path, manifest, include_diagnostics=False)
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    event = H5HeaderSpotter(cfg).predict(dataset)["data"][0]["events"][0]
+
+    assert "metadata" not in event
+
+
+def test_header_rule_skips_centroid_only_samples(tmp_path):
+    _write_ball(tmp_path / "ball.h5")
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(manifest, input_type="player_centroids_h5")
+    cfg = _config(tmp_path, manifest, input_type="player_centroids_h5")
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    predictions = H5HeaderSpotter(cfg).predict(dataset)
+
+    assert predictions["data"][0]["events"] == []
+
+
+def test_position_ms_is_relative_to_joint_h5_start_not_metadata_start(tmp_path):
+    _write_ball(tmp_path / "ball.h5")
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(
+        manifest,
+        metadata={
+            "start_utc": "2026-01-01 00:00:00.020000",
+            "end_utc": "2026-01-01 00:00:00.020000",
+        },
+    )
+    cfg = _config(tmp_path, manifest)
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    predictions = H5HeaderSpotter(cfg).predict(dataset)
+
+    events = predictions["data"][0]["events"]
+    assert len(events) == 1
+    assert events[0]["timestamp_utc"] == "2026-01-01 00:00:00.020000"
+    assert events[0]["position_ms"] == 20
+
+
+def test_position_ms_uses_earliest_joint_h5_timestamp_when_rows_are_unsorted(tmp_path):
+    _write_ball(tmp_path / "ball.h5")
+    _write_unsorted_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(
+        manifest,
+        metadata={
+            "start_utc": "2026-01-01 00:00:00.020000",
+            "end_utc": "2026-01-01 00:00:00.020000",
+        },
+    )
+    cfg = _config(tmp_path, manifest)
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    predictions = H5HeaderSpotter(cfg).predict(dataset)
+
+    events = predictions["data"][0]["events"]
+    assert len(events) == 1
+    assert events[0]["timestamp_utc"] == "2026-01-01 00:00:00.020000"
+    assert events[0]["position_ms"] == 20
+    assert events[0]["position_ms"] >= 0
+
+
+def test_sideline_filter_excludes_candidate_using_ball_y(tmp_path):
+    _write_ball_from_rows(
+        tmp_path / "ball.h5",
+        [
+            ("2026-01-01 00:00:00.000000", 0.0, 0.0, 0.0),
+            ("2026-01-01 00:00:00.020000", 0.10, 49.5, 0.0),
+            ("2026-01-01 00:00:00.040000", 0.2, 0.0, 0.0),
+        ],
+    )
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(
+        manifest,
+        metadata={
+            "start_utc": "2026-01-01 00:00:00.020000",
+            "end_utc": "2026-01-01 00:00:00.020000",
+        },
+    )
+    cfg = _config(
+        tmp_path,
+        manifest,
+        rule_overrides={
+            "sideline_filter_enabled": True,
+            "trajectory_filter_enabled": False,
+        },
+    )
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    predictions = H5HeaderSpotter(cfg).predict(dataset)
+
+    assert predictions["data"][0]["events"] == []
+
+
+def test_angle_change_trajectory_passes_and_adds_diagnostics(tmp_path):
+    _write_ball_from_rows(
+        tmp_path / "ball.h5",
+        [
+            ("2026-01-01 00:00:00.000000", -0.20, 0.0, 0.0),
+            ("2026-01-01 00:00:00.020000", 0.05, 0.0, 0.0),
+            ("2026-01-01 00:00:00.040000", 0.05, 0.30, 0.0),
+        ],
+    )
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(
+        manifest,
+        metadata={
+            "start_utc": "2026-01-01 00:00:00.020000",
+            "end_utc": "2026-01-01 00:00:00.020000",
+        },
+    )
+    cfg = _config(
+        tmp_path,
+        manifest,
+        rule_name="h5_header_distance_angle",
+        rule_overrides={
+            "sideline_filter_enabled": True,
+            "trajectory_min_angle_deg": 25.0,
+            "trajectory_min_speed_delta_ratio": 10.0,
+            "trajectory_min_vector_norm_m": 0.01,
+        },
+    )
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    event = H5HeaderSpotter(cfg).predict(dataset)["data"][0]["events"][0]
+
+    assert event["confidence_score"] > 0.5
+    metadata = event["metadata"]
+    assert metadata["ball_y"] == 0.0
+    assert metadata["sideline_distance_m"] == 50.0
+    assert metadata["trajectory_passed"] is True
+    assert metadata["trajectory_angle_deg"] >= 25.0
+
+
+def test_speed_change_trajectory_passes_when_angle_does_not(tmp_path):
+    _write_ball_from_rows(
+        tmp_path / "ball.h5",
+        [
+            ("2026-01-01 00:00:00.000000", -0.05, 0.0, 0.0),
+            ("2026-01-01 00:00:00.020000", 0.05, 0.0, 0.0),
+            ("2026-01-01 00:00:00.040000", 0.45, 0.0, 0.0),
+        ],
+    )
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(
+        manifest,
+        metadata={
+            "start_utc": "2026-01-01 00:00:00.020000",
+            "end_utc": "2026-01-01 00:00:00.020000",
+        },
+    )
+    cfg = _config(
+        tmp_path,
+        manifest,
+        rule_name="h5_header_distance_speed",
+        rule_overrides={
+            "trajectory_min_angle_deg": 25.0,
+            "trajectory_min_speed_delta_ratio": 0.25,
+            "trajectory_min_vector_norm_m": 0.01,
+        },
+    )
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    event = H5HeaderSpotter(cfg).predict(dataset)["data"][0]["events"][0]
+
+    assert event["metadata"]["trajectory_angle_deg"] == 0.0
+    assert event["metadata"]["trajectory_speed_delta_ratio"] >= 0.25
+    assert event["metadata"]["trajectory_passed"] is True
+
+
+def test_speed_angle_variant_requires_both_trajectory_changes(tmp_path):
+    _write_ball_from_rows(
+        tmp_path / "ball.h5",
+        [
+            ("2026-01-01 00:00:00.000000", -0.10, 0.0, 0.0),
+            ("2026-01-01 00:00:00.020000", 0.05, 0.0, 0.0),
+            ("2026-01-01 00:00:00.040000", 0.05, 0.30, 0.0),
+        ],
+    )
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(
+        manifest,
+        metadata={
+            "start_utc": "2026-01-01 00:00:00.020000",
+            "end_utc": "2026-01-01 00:00:00.020000",
+        },
+    )
+    cfg = _config(
+        tmp_path,
+        manifest,
+        rule_name="h5_header_distance_speed_angle",
+        rule_overrides={
+            "trajectory_min_angle_deg": 25.0,
+            "trajectory_min_speed_delta_ratio": 0.25,
+            "trajectory_min_vector_norm_m": 0.01,
+        },
+    )
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    event = H5HeaderSpotter(cfg).predict(dataset)["data"][0]["events"][0]
+
+    assert event["metadata"]["trajectory_angle_deg"] >= 25.0
+    assert event["metadata"]["trajectory_speed_delta_ratio"] >= 0.25
+    assert event["metadata"]["trajectory_passed"] is True
+
+
+def test_trajectory_filter_rejects_when_context_is_insufficient(tmp_path):
+    _write_ball_from_rows(
+        tmp_path / "ball.h5",
+        [
+            ("2026-01-01 00:00:00.020000", 0.05, 0.0, 0.0),
+        ],
+    )
+    _write_joints(tmp_path / "joints.h5")
+    manifest = tmp_path / "h5.json"
+    _write_manifest(
+        manifest,
+        metadata={
+            "start_utc": "2026-01-01 00:00:00.020000",
+            "end_utc": "2026-01-01 00:00:00.020000",
+        },
+    )
+    cfg = _config(tmp_path, manifest, rule_name="h5_header_distance_speed")
+
+    dataset_obj = LocalizationDataset(cfg, split="test")
+    dataset = dataset_obj.building_dataset(dataset_obj.cfg)
+    predictions = H5HeaderSpotter(cfg).predict(dataset)
+
+    assert predictions["data"][0]["events"] == []
+
+
+def test_rule_based_train_is_inference_only(tmp_path):
+    manifest = tmp_path / "h5.json"
+    _write_manifest(manifest)
+    cfg_path = tmp_path / "config.yaml"
+    OmegaConf.save(_config(tmp_path, manifest), cfg_path)
+
+    api = LocalizationModel(config=str(cfg_path))
+
+    with pytest.raises(NotImplementedError, match="inference-only"):
+        api.train(use_wandb=False)

--- a/tests/test_h5_tracking_dataset.py
+++ b/tests/test_h5_tracking_dataset.py
@@ -1,0 +1,196 @@
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+
+from opensportslib.datasets.classification_dataset import H5TrackingDataset
+from opensportslib.datasets.utils.h5_tracking import H5TrackingReader, H5_FEATURE_DIM
+
+
+def _bytes(values):
+    return np.asarray([value.encode("utf-8") for value in values], dtype="S26")
+
+
+def _write_centroids(path: Path):
+    timestamps = [
+        "2026-01-01 00:00:00.000000",
+        "2026-01-01 00:00:00.000000",
+        "2026-01-01 00:00:00.020000",
+        "2026-01-01 00:00:00.020000",
+        "2026-01-01 00:00:00.040000",
+        "2026-01-01 00:00:00.040000",
+    ]
+    with h5py.File(path, "w") as f:
+        f.create_dataset("timestamp_utc", data=_bytes(timestamps))
+        f.create_dataset("x", data=np.asarray([0, 10, 1, 11, 2, 12], dtype=np.float64))
+        f.create_dataset("y", data=np.asarray([0, 20, 1, 21, 2, 22], dtype=np.float64))
+        f.create_dataset("player_id", data=_bytes(["p1", "p2", "p1", "p2", "p1", "p2"]))
+        f.create_dataset("jersey_number", data=_bytes(["1", "2", "1", "2", "1", "2"]))
+        f.create_dataset("is_home", data=np.asarray([1, 0, 1, 0, 1, 0], dtype=np.int64))
+        f.create_dataset("role_name", data=_bytes(["MID", "DEF", "MID", "DEF", "MID", "DEF"]))
+
+
+def _write_joints(path: Path):
+    timestamps = [
+        "2026-01-01 00:00:00.000000",
+        "2026-01-01 00:00:00.020000",
+    ]
+    with h5py.File(path, "w") as f:
+        f.create_dataset("timestamp_utc", data=_bytes(timestamps))
+        f.create_dataset("player_id", data=_bytes(["p1", "p1"]))
+        f.create_dataset("jersey_number", data=_bytes(["1", "1"]))
+        f.create_dataset("is_home", data=np.asarray([1, 1], dtype=np.int64))
+        f.create_dataset("role_name", data=_bytes(["MID", "MID"]))
+        for joint in ["nose", "neck"]:
+            f.create_dataset(f"{joint}_x", data=np.asarray([1.0, 2.0]))
+            f.create_dataset(f"{joint}_y", data=np.asarray([3.0, 4.0]))
+            f.create_dataset(f"{joint}_z", data=np.asarray([5.0, 6.0]))
+
+
+def _write_ball(path: Path, *, offset_ms=0):
+    base = np.datetime64("2026-01-01T00:00:00.000000", "us")
+    timestamps = [
+        str((base + np.timedelta64(offset_ms + i * 20, "ms")).astype("datetime64[us]")).replace("T", " ")
+        for i in range(3)
+    ]
+    with h5py.File(path, "w") as f:
+        f.create_dataset("timestamp_utc", data=_bytes(timestamps))
+        f.create_dataset("x", data=np.asarray([100, 101, 102], dtype=np.float64))
+        f.create_dataset("y", data=np.asarray([200, 201, 202], dtype=np.float64))
+        f.create_dataset("z", data=np.asarray([3, 4, 5], dtype=np.float64))
+
+
+def _write_annotation(path: Path, input_type: str, input_path: str, ball_path: str | None = None):
+    input_obj = {"type": input_type, "path": input_path}
+    if ball_path:
+        input_obj["ball_path"] = ball_path
+    payload = {
+        "labels": {"action": {"type": "single_label", "labels": ["HEADER"]}},
+        "data": [
+            {
+                "id": "sample_h5",
+                "inputs": [input_obj],
+                "metadata": {
+                    "start_utc": "2026-01-01 00:00:00.020000",
+                    "end_utc": "2026-01-01 00:00:00.040000",
+                },
+                "labels": {"action": {"label": "HEADER"}},
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _config(root: Path, modality="player_centroids_h5", num_frames=None, tolerance_ms=25.0):
+    return SimpleNamespace(
+        DATA=SimpleNamespace(
+            common=SimpleNamespace(
+                splits=SimpleNamespace(train=SimpleNamespace(source_path=str(root))),
+            ),
+            inputs=SimpleNamespace(
+                tracking=SimpleNamespace(
+                    modality=modality,
+                    sampling=SimpleNamespace(num_frames=num_frames),
+                    transform=SimpleNamespace(normalize=False),
+                    augmentations=SimpleNamespace(),
+                    params=SimpleNamespace(timestamp_tolerance_ms=tolerance_ms),
+                )
+            ),
+        ),
+        MODEL=SimpleNamespace(
+            components=SimpleNamespace(
+                encoder=SimpleNamespace(
+                    kind="encoder",
+                    source=SimpleNamespace(name="graph_conv"),
+                    params=SimpleNamespace(edge_type="none"),
+                    overrides=SimpleNamespace(),
+                )
+            )
+        ),
+    )
+
+
+def test_h5_reader_clips_by_utc_and_aligns_ball(tmp_path):
+    centroids = tmp_path / "centroids.h5"
+    ball = tmp_path / "ball.h5"
+    _write_centroids(centroids)
+    _write_ball(ball)
+
+    reader = H5TrackingReader(centroids, "player_centroids_h5", ball_path=ball, timestamp_tolerance_ms=5)
+    timestamps = reader.select_timestamps(
+        start_utc="2026-01-01 00:00:00.020000",
+        end_utc="2026-01-01 00:00:00.040000",
+    )
+    frames = reader.read_sequence(timestamps)
+
+    assert [str(ts) for ts in timestamps] == [
+        "2026-01-01T00:00:00.020000",
+        "2026-01-01T00:00:00.040000",
+    ]
+    assert frames[0].features.shape == (3, H5_FEATURE_DIM)
+    assert frames[0].features[0, :3].tolist() == [101.0, 201.0, 4.0]
+    assert frames[1].features[1, 6] == 1.0
+
+
+def test_h5_reader_out_of_tolerance_ball_uses_missing_node(tmp_path):
+    centroids = tmp_path / "centroids.h5"
+    ball = tmp_path / "ball.h5"
+    _write_centroids(centroids)
+    _write_ball(ball, offset_ms=1000)
+
+    reader = H5TrackingReader(centroids, "player_centroids_h5", ball_path=ball, timestamp_tolerance_ms=5)
+    timestamps = reader.select_timestamps(
+        start_utc="2026-01-01 00:00:00.000000",
+        end_utc="2026-01-01 00:00:00.000000",
+    )
+    frames = reader.read_sequence(timestamps)
+
+    assert frames[0].entity_ids[0] == "BALL"
+    assert frames[0].features[0, 0] == -200.0
+
+
+def test_h5_dataset_resolves_ball_path_and_returns_graphs(tmp_path, monkeypatch):
+    centroids = tmp_path / "centroids.h5"
+    ball = tmp_path / "ball.h5"
+    annotation = tmp_path / "annotations.json"
+    _write_centroids(centroids)
+    _write_ball(ball)
+    _write_annotation(annotation, "player_centroids_h5", "centroids.h5", "ball.h5")
+
+    data_module = types.ModuleType("torch_geometric.data")
+
+    class Data:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    data_module.Data = Data
+    torch_geometric_module = types.ModuleType("torch_geometric")
+    torch_geometric_module.data = data_module
+    monkeypatch.setitem(sys.modules, "torch_geometric", torch_geometric_module)
+    monkeypatch.setitem(sys.modules, "torch_geometric.data", data_module)
+
+    dataset = H5TrackingDataset(_config(tmp_path), str(annotation), split="train")
+    sample = dataset[0]
+
+    assert dataset.samples[0]["inputs"][0]["ball_path"] == "ball.h5"
+    assert sample["id"] == "sample_h5"
+    assert sample["seq_len"] == 2
+    assert sample["graphs"][0].x.shape == (3, H5_FEATURE_DIM)
+    assert sample["label"] == 0
+
+
+def test_h5_reader_materializes_joint_nodes(tmp_path):
+    joints = tmp_path / "joints.h5"
+    _write_joints(joints)
+
+    reader = H5TrackingReader(joints, "player_joints_h5")
+    timestamps = reader.select_timestamps(num_frames=1)
+    frames = reader.read_sequence(timestamps)
+
+    assert frames[0].features.shape == (2, H5_FEATURE_DIM)
+    assert all(entity_id.endswith(("neck", "nose")) for entity_id in frames[0].entity_ids)
+    assert frames[0].features[:, 9].tolist() == [1.0, 1.0]


### PR DESCRIPTION
- Updated `build_model_canonical` to include a new rule-based model option.
- Introduced `run_h5_header_rule_inference.py` for YAML-configured H5 header spotting and saving predictions.
- Added tests for the new rule-based header spotting functionality, including various scenarios and edge cases.
- Created `H5TrackingDataset` and associated tests for handling tracking data with ball and joint information.
- Updated dependencies in `pyproject.toml` to include `h5py`.