### PR TITLE
feat: add release verification test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ dcgm
 
 
 checkpoints_tracking/
+
+# Release verification tests (tests/release/) download real datasets and
+# write checkpoints/logs here -- never commit it.
+.release_test_cache/

--- a/opensportslib/core/optimizer/builder.py
+++ b/opensportslib/core/optimizer/builder.py
@@ -39,4 +39,14 @@ def build_optimizer(parameters, cfg, default_args=None):
             weight_decay=cfg.weight_decay,
             amsgrad=cfg.amsgrad,
         )
+    elif cfg.type == "SGD":
+        optimizer = torch.optim.SGD(
+            parameters,
+            lr=cfg.lr,
+            momentum=getattr(cfg, "momentum", 0.0),
+            weight_decay=getattr(cfg, "weight_decay", 0.0),
+            nesterov=getattr(cfg, "nesterov", False),
+        )
+    else:
+        raise ValueError(f"Unsupported optimizer type: {cfg.type}")
     return optimizer

--- a/opensportslib/models/backbones/builder.py
+++ b/opensportslib/models/backbones/builder.py
@@ -253,7 +253,7 @@ class RegnetyExtractFeatures(BaseExtractFeatures):
         self._feat_dim = feat_dim
 
 
-class ResnetExtractFeatures(nn.Module):
+class ResnetExtractFeatures(BaseExtractFeatures):
     """Feature extractor which is based on the "resnet" models of the torchvision models.
     The model is adapted for this task by adding temporal shift modules.
 

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Convenience wrapper for tests/release/ -- extensive real-dataset,
+# real-training verification, meant to be run manually after a big release.
+# See tests/release/README.md for full documentation.
+#
+# This does NOT run automatically as part of any other script; it must be
+# invoked directly, and requires RUN_OSL_RELEASE_TESTS=1 to actually execute
+# anything (the tests skip themselves otherwise).
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ "${RUN_OSL_RELEASE_TESTS:-}" != "1" ]]; then
+  echo "RUN_OSL_RELEASE_TESTS is not set to 1 -- refusing to run."
+  echo "This suite downloads real (sometimes large) datasets and runs real"
+  echo "training. Set RUN_OSL_RELEASE_TESTS=1 to proceed. See"
+  echo "tests/release/README.md for prerequisites and tuning."
+  exit 1
+fi
+
+echo "OpenSportsLib Release Verification"
+echo "Repository: $ROOT_DIR"
+echo "Cache dir : ${OSL_RELEASE_CACHE_DIR:-$ROOT_DIR/.release_test_cache}"
+echo ""
+
+exec pytest tests/release -v -s "$@"

--- a/tests/release/README.md
+++ b/tests/release/README.md
@@ -1,0 +1,187 @@
+# Release verification tests
+
+Extensive, real-data, real-training tests for confirming that training still
+works end-to-end for (most of) the model families OpenSportsLib ships, after
+a big release. **These are not part of the regular test contract** — they are
+not run by `pytest tests/test_*.py` (AGENTS.md's mandatory pre-PR command,
+which only globs flat files directly under `tests/`) and every test here
+additionally skips itself unless `RUN_OSL_RELEASE_TESTS=1` is set, so they
+never run by accident even under a broad `pytest tests/`.
+
+Do not add these to CI. Run them manually, on a machine with a real GPU, real
+disk space, and time to spare.
+
+## What's covered
+
+Every dataset fixture prefers a dataset pinned in the
+[`OpenSportsLab/osl-ready-datasets`](https://huggingface.co/collections/OpenSportsLab/osl-ready-datasets)
+Hugging Face collection — the org's sharded (parquet + webdataset) datasets —
+and falls back to a known-good, real, but loose-file dataset only while the
+sharded one isn't populated yet. See "Preferring OSL-ready (sharded)
+datasets" below.
+
+| File | Task | OSL-ready (preferred) | Fallback (used until the above is published) | Model families |
+| --- | --- | --- | --- | --- |
+| `test_classification_release.py` | classification | `OpenSportsLab/OSL-XFoul`¹ | `OpenSportsLab/OSL-cls-UEFA-fouls` (gated) | MVNetwork (r3d_18, mc3_18, r2plus1d_18, s3d, mvit_v2_s), HF VideoMAE full-model |
+| `test_localization_release.py` | localization (E2E) | `OpenSportsLab/OSL-SNBAS` | `OpenSportsLab/soccernetpro-localization-tennis` (public) | E2E (rn18/rn50/rny002/rny008_gsm/convnextt x gru/deeper_gru/mstcn/asformer), E2E+DALI |
+| `test_localization_release.py` | localization (features) | `OpenSportsLab/OSL-SoccerNet` | `OpenSportsLab/SoccerNet-ActionSpotting-Features` (public, ~111GB full) | ContextAware (CALF), LearnablePooling (NetVLAD++) |
+| `test_vqa_release.py` | VQA | `OpenSportsLab/OSL-XFoul`¹ | none — skips if unpublished | X-VARS/VideoChatGPT LoRA, CLIP+Qwen LoRA, native QwenVL LoRA |
+
+¹ OSL-XFoul is dual-purpose: the same RefPal/MVFouls-style clips carry both
+classification labels and VQA question/answers, so it's the preferred
+dataset for both tasks.
+
+As of the last check, all three OSL-ready datasets (`OSL-XFoul`, `OSL-SNBAS`,
+`OSL-SoccerNet`) are unpublished placeholder repos, so every fixture
+currently takes its fallback path. Re-run after any of them lands to switch
+automatically — no code change needed.
+
+Known gaps, marked `skip` with a reason rather than a fake pass:
+
+- The `frames_npy` VideoModel classification family (dinov3, clip, videomae,
+  videomae2 as pure feature extractors) needs a raw-video → frame-`.npy`
+  pre-extraction step this suite doesn't implement yet.
+- Tracking-modality classification (`graph_conv`,
+  `classification/sngar_tracking.yaml`) depends on
+  `OpenSportsLab/SoccerNet-GAR`, which is an unpublished placeholder repo as
+  of this writing.
+- Retrieval and description/captioning have no first-class training workflow
+  in the library yet (per the README's roadmap section), so there's nothing
+  to verify here.
+
+## Prerequisites
+
+- A working `opensportslib` install with GPU support (`opensportslib setup`).
+- For the VQA backends: `opensportslib setup --vqa_xvars` and/or
+  `opensportslib setup --vqa_qwen`. Tests skip cleanly (not fail) if the
+  relevant optional dependency isn't installed.
+- For DALI E2E localization: `opensportslib setup --dali`. Skips cleanly if
+  absent.
+- `HF_TOKEN` (or `HUGGINGFACE_TOKEN`) exported for any gated dataset —
+  currently `OSL-cls-UEFA-fouls`. Request access on the dataset's HF page
+  first; tests skip with instructions if access isn't granted.
+- Disk space: the tennis and UEFA-fouls datasets are small (~250MB–1.4GB),
+  but the full `SoccerNet-ActionSpotting-Features` dataset is ~111GB and the
+  QwenVL-native VQA backend downloads an 8B-parameter model. Set
+  `OSL_RELEASE_DATA_DIR` to point dataset downloads at a disk with room —
+  and reuse it across runs, since already-downloaded files won't be
+  re-fetched.
+
+## Running
+
+```bash
+# Everything (expensive -- real training runs across every backbone/head
+# combination). Dataset downloads are capped by default (see "Why file
+# counts are capped" below), so this is real but bounded, not 100GB+:
+RUN_OSL_RELEASE_TESTS=1 pytest tests/release -v -s
+RUN_OSL_RELEASE_TESTS=1 OSL_RELEASE_DATA_DIR=~/OSLdata \
+    pytest tests/release -v -s
+
+# Just one task:
+RUN_OSL_RELEASE_TESTS=1 pytest tests/release/test_localization_release.py -v -s
+RUN_OSL_RELEASE_TESTS=1 OSL_RELEASE_DATA_DIR=~/OSLdata \
+    pytest tests/release/test_localization_release.py -v -s
+
+# Just one backbone/config:
+RUN_OSL_RELEASE_TESTS=1 pytest tests/release -v -s -k "rn18-gru"
+
+# Skip the heaviest tests:
+RUN_OSL_RELEASE_TESTS=1 pytest tests/release -v -s -m "not slow"
+
+# True full-scale run on the fallback datasets (every file, e.g. the full
+# ~111GB feature dataset) -- irrelevant once the OSL-ready primaries land,
+# since those download a handful of shard files regardless of this setting:
+RUN_OSL_RELEASE_TESTS=1 OSL_RELEASE_MAX_CLIPS=all OSL_RELEASE_MAX_GAMES=all \\
+    pytest tests/release -v -s
+```
+
+Or use the convenience wrapper (same env-var gate, same defaults):
+
+```bash
+RUN_OSL_RELEASE_TESTS=1 scripts/run_release_tests.sh
+```
+
+## Tuning a run
+
+### Preferring OSL-ready (sharded) datasets
+
+The org publishes a curated set of datasets as parquet + webdataset shards —
+a handful of large files per split — under the
+[`OpenSportsLab/osl-ready-datasets`](https://huggingface.co/collections/OpenSportsLab/osl-ready-datasets)
+collection, specifically so consumers don't have to pull thousands of
+individual clips one at a time. Every dataset fixture in this suite calls
+`_release_common.prefer_osl_ready_dataset(primary, fallback)`: it checks
+whether the OSL-ready `primary` repo is populated yet and, if so, downloads
+it via `_release_common.download_shard_split()` — a thin wrapper around
+`opensportslib.tools.hf_transfer.download_dataset_split_from_hf(...,
+download_format="parquet")`, which does
+`snapshot_download(allow_patterns=[f"{split}/*"])` and converts the result
+to a local OSL v2 JSON. Only if `primary` isn't populated yet does it fall
+back to `fallback` — a known-good, currently-populated but non-sharded
+dataset, downloaded with the file-count capping described below.
+
+This means: no dataset-count-capping env var below has any effect once the
+corresponding OSL-ready dataset is published — a sharded download is a
+handful of files regardless of how many samples are in the split. The caps
+only matter for the fallback path, which is what every fixture currently
+uses (see the table above).
+
+### Why fallback file counts are capped by default
+
+The fallback datasets are loose per-clip/per-game files on the Hub (3450
+files for the tennis dataset, 2210 for the SoccerNet feature dataset).
+Downloading thousands of individual small files is slow and can trip
+Hugging Face's API rate limit (1000 requests/5min on a free account — this
+suite has hit it). So the fallback path in each fixture lists files first
+(one cheap API call), then downloads only an annotation file plus a capped
+number of referenced media files — never a blind "download the whole repo".
+
+### Variables
+
+Every test honors these environment variables so a run can be scaled from a
+quick sanity pass up to a full release-scale run:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `OSL_RELEASE_CACHE_DIR` | `<repo>/.release_test_cache` | Where materialized configs and run outputs (checkpoints/logs/predictions) go. |
+| `OSL_RELEASE_DATA_DIR` | `<cache dir>/data` | Where datasets are downloaded to / read from. Point this at a folder that already hosts the datasets (a shared drive, a previous run) and nothing gets re-downloaded or overwritten — huggingface_hub only fetches files that are missing or changed. Independent of `OSL_RELEASE_CACHE_DIR` so a large, reusable dataset cache can live separately from ephemeral run outputs. |
+| `OSL_RELEASE_EPOCHS` | varies per test (1–3) | `TRAIN.epochs` override. `0` keeps each config's own default. |
+| `OSL_RELEASE_MAX_CLIPS` | `40` | **Fallback only.** Cap on localization E2E clips downloaded per split (tennis dataset, 3450 files total). `all` forces the full dataset. No effect once `OSL-SNBAS` is published. |
+| `OSL_RELEASE_MAX_GAMES` | `10` | **Fallback only.** Cap on games downloaded per split for the feature-based (CALF/NetVLAD++) localization tests (2210 files total). `all` downloads the full ~111GB dataset. No effect once `OSL-SoccerNet` is published. |
+| `OSL_RELEASE_CLS_NUM_FRAMES` | `16` | `DATA.inputs.video.sampling.num_frames` override for the classification backbones. |
+| `OSL_RELEASE_CLS_REPO` | `OpenSportsLab/OSL-XFoul` | Override the preferred (OSL-ready) classification dataset. |
+| `OSL_RELEASE_CLS_FALLBACK_REPO` | `OpenSportsLab/OSL-cls-UEFA-fouls` | Override the fallback classification dataset. |
+| `OSL_RELEASE_LOC_E2E_REPO` | `OpenSportsLab/OSL-SNBAS` | Override the preferred (OSL-ready) E2E localization dataset. |
+| `OSL_RELEASE_LOC_E2E_FALLBACK_REPO` | `OpenSportsLab/soccernetpro-localization-tennis` | Override the fallback E2E localization dataset. |
+| `OSL_RELEASE_LOC_FEATURES_REPO` | `OpenSportsLab/OSL-SoccerNet` | Override the preferred (OSL-ready) feature-based localization dataset. |
+| `OSL_RELEASE_LOC_FEATURES_FALLBACK_REPO` | `OpenSportsLab/SoccerNet-ActionSpotting-Features` | Override the fallback feature-based localization dataset. |
+| `OSL_RELEASE_VQA_REPO` | `OpenSportsLab/OSL-XFoul` | Override the VQA dataset (no fallback exists). |
+| `HF_TOKEN` / `HUGGINGFACE_TOKEN` | unset | Auth for gated dataset repos (currently the classification fallback). |
+
+## How configs are built
+
+`opensportslib/configs/<task>/<name>.yaml` files are not self-contained — the
+library layers them on top of `opensportslib/configs/default.yaml` and
+`opensportslib/configs/<task>/default.yaml` at load time, but only when the
+config path physically lives inside `opensportslib/configs/<task>/` (see
+`opensportslib/core/config/loader.py::_compose_yaml_layers`). `_release_common.
+materialize_config()` reuses the library's own `load_config()` to get that
+real composition, deep-merges this suite's dataset/run overrides on top, and
+writes the fully-resolved result under `OSL_RELEASE_CACHE_DIR/configs/` so it
+loads as a plain standalone file. This means every release test trains with
+the same defaults a real user gets from the canonical config, not a
+hand-rolled approximation of them.
+
+## Updating this suite after a release
+
+If a release adds a new backbone, head, or task:
+
+1. Add it to the relevant matrix (`MVNETWORK_BACKBONES`, `E2E_BACKBONES`/
+   `E2E_HEADS`/`E2E_MATRIX`, etc.).
+2. If it needs a new canonical config, make sure one exists under
+   `opensportslib/configs/<task>/` first — these tests deliberately don't
+   hand-roll model configs, they override the real ones.
+3. If a dataset referenced here has changed shape (most likely: `OSL-XFoul`
+   going from an empty placeholder to a real upload, or `OSL-cls-UEFA-fouls`'s
+   label schema), fix the conversion helper called out in that test file's
+   module docstring — each one names the exact function to look at first.

--- a/tests/release/_release_common.py
+++ b/tests/release/_release_common.py
@@ -1,0 +1,372 @@
+"""Shared helpers for the release-verification test suite (tests/release/).
+
+These tests are NOT part of the regular `pytest tests/test_*.py` contract.
+They download real datasets from the OpenSportsLab Hugging Face org
+(some of them large) and run real training/inference/evaluation on GPU.
+They exist to be run manually after a big release to confirm that training
+still works end-to-end for every model family the library ships.
+
+See tests/release/README.md for the full contract, prerequisites, and
+invocation examples.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RELEASE_ENV_FLAG = "RUN_OSL_RELEASE_TESTS"
+
+# Where materialized configs / run outputs (checkpoints, logs, predictions)
+# are cached. Override with OSL_RELEASE_CACHE_DIR to point at a disk with
+# more room.
+CACHE_ROOT = Path(
+    os.environ.get("OSL_RELEASE_CACHE_DIR", str(REPO_ROOT / ".release_test_cache"))
+).expanduser()
+CONFIG_DIR = CACHE_ROOT / "configs"
+OUTPUT_DIR = CACHE_ROOT / "outputs"
+
+# Where datasets are downloaded to / read from. Deliberately independent of
+# CACHE_ROOT: point OSL_RELEASE_DATA_DIR at a folder that already hosts these
+# datasets (a shared drive, a previous run's download, ...) and nothing gets
+# re-downloaded or overwritten -- snapshot_dataset()/download_files() below
+# pass this straight through as `local_dir` to huggingface_hub, which only
+# fetches files that are missing or whose content has changed (standard HF
+# Hub behavior; see https://huggingface.co/docs/huggingface_hub/guides/download).
+# Defaults to a subdirectory of CACHE_ROOT when unset.
+DATA_DIR = Path(
+    os.environ.get("OSL_RELEASE_DATA_DIR", str(CACHE_ROOT / "data"))
+).expanduser()
+
+for _d in (DATA_DIR, CONFIG_DIR, OUTPUT_DIR):
+    _d.mkdir(parents=True, exist_ok=True)
+
+
+# --------------------------------------------------------------------------
+# Opt-in gate
+# --------------------------------------------------------------------------
+
+
+def release_tests_enabled() -> bool:
+    return os.environ.get(RELEASE_ENV_FLAG, "") == "1"
+
+
+def require_release_enabled() -> None:
+    """Call at the top of every release test / fixture.
+
+    Keeps these tests from ever running by accident (plain `pytest tests/`,
+    an IDE "run all tests" button, a CI job someone forgot to scope) even
+    though pytest can discover them. The flat `pytest tests/test_*.py`
+    command from AGENTS.md never reaches this directory in the first place
+    since it's a shell glob, not a recursive pattern — this is the second,
+    explicit line of defense for anyone running `pytest tests/` directly.
+    """
+    if not release_tests_enabled():
+        pytest.skip(
+            f"Release verification tests are opt-in. "
+            f"Set {RELEASE_ENV_FLAG}=1 to run them (see tests/release/README.md). "
+            f"They download real datasets and run real training; do not enable "
+            f"them in routine CI."
+        )
+
+
+# --------------------------------------------------------------------------
+# Tunables (env-overridable so a maintainer can scale a run up or down)
+# --------------------------------------------------------------------------
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return int(raw)
+
+
+def epochs_for(default: int) -> int:
+    """TRAIN.epochs override. OSL_RELEASE_EPOCHS=0 means 'keep config default'."""
+    value = _env_int("OSL_RELEASE_EPOCHS", default)
+    return default if value == 0 else value
+
+
+def max_items_for(env_name: str, default: int | None) -> int | None:
+    """Generic dataset-subset-size override. 0 (or 'all') means 'download everything'."""
+    raw = os.environ.get(env_name)
+    if raw is None or raw == "":
+        return default
+    if raw.strip().lower() == "all":
+        return None
+    value = int(raw)
+    return None if value == 0 else value
+
+
+def hf_token() -> str | None:
+    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_TOKEN")
+
+
+def optional_module_available(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+# --------------------------------------------------------------------------
+# Hugging Face dataset access helpers
+# --------------------------------------------------------------------------
+
+
+def _hf_api():
+    from huggingface_hub import HfApi
+
+    return HfApi(token=hf_token())
+
+
+def repo_accessible(repo_id: str, repo_type: str = "dataset") -> bool:
+    """True if we can read repo metadata (i.e. it's public or we're authorized).
+
+    Distinguishes "gated/private, no access" (returns False -> caller should
+    skip) from genuine infrastructure problems (network down, HF outage),
+    which are re-raised so the test fails loudly instead of silently skipping.
+    """
+    from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+    from requests.exceptions import ConnectionError as RequestsConnectionError
+
+    try:
+        _hf_api().repo_info(repo_id, repo_type=repo_type)
+        return True
+    except (GatedRepoError, RepositoryNotFoundError):
+        return False
+    except RequestsConnectionError:
+        raise
+
+
+def require_repo_access(repo_id: str, repo_type: str = "dataset") -> None:
+    if not repo_accessible(repo_id, repo_type=repo_type):
+        pytest.skip(
+            f"No access to {repo_id!r} on Hugging Face. It may be gated — "
+            f"request access at https://huggingface.co/datasets/{repo_id} and "
+            f"export HF_TOKEN (or HUGGINGFACE_TOKEN) for an account that has "
+            f"been granted access, then re-run."
+        )
+
+
+def list_repo_files(repo_id: str, repo_type: str = "dataset") -> list[str]:
+    """List a repo's files with a single cheap API call -- use this to find
+    what you actually need (e.g. small annotation JSONs) before downloading
+    anything, rather than snapshot-downloading an entire many-file repo.
+    """
+    return list(_hf_api().list_repo_files(repo_id, repo_type=repo_type))
+
+
+def repo_is_populated(repo_id: str, repo_type: str = "dataset", min_files: int = 2, revision: str = "main") -> bool:
+    """Some OpenSportsLab dataset repos have nothing but a placeholder (just
+    a .gitattributes / README) on their default branch while the real data
+    lives on a named branch (see prefer_osl_ready_dataset() below) -- always
+    pass the branch you actually intend to read from. Treat a repo/revision
+    with no real files as "not yet available" rather than crashing on an
+    empty split.
+    """
+    files = _hf_api().list_repo_files(repo_id, repo_type=repo_type, revision=revision)
+    real_files = [f for f in files if f not in (".gitattributes", "README.md")]
+    return len(real_files) >= min_files
+
+
+def require_repo_populated(repo_id: str, repo_type: str = "dataset", min_files: int = 2, revision: str = "main") -> None:
+    if not repo_is_populated(repo_id, repo_type=repo_type, min_files=min_files, revision=revision):
+        pytest.skip(
+            f"{repo_id!r}@{revision} does not have data uploaded yet. This "
+            f"test is ready to run as soon as the dataset/branch is "
+            f"published — re-run once it is."
+        )
+
+
+# --------------------------------------------------------------------------
+# OSL-ready (sharded) datasets
+#
+# https://huggingface.co/collections/OpenSportsLab/osl-ready-datasets pins
+# the datasets the org publishes as parquet + webdataset shards (a handful
+# of large files per split) rather than one file per clip/game -- always
+# prefer these when they're populated. Use prefer_osl_ready_dataset() to try
+# a collection dataset first and fall back to a known-good loose-file
+# dataset only while the sharded one isn't published yet.
+#
+# Important: for every OSL-ready repo observed so far, the *default* ("main")
+# branch is an empty placeholder -- the actual shards live on named branches
+# (e.g. "224p", "720p", "ResNET_PCA512", "224p-2024"). Always pass the
+# specific revision you want; there is no sensible repo-wide default.
+# --------------------------------------------------------------------------
+
+
+def download_shard_split(repo_id: str, split: str, output_dir: Path, *, revision: str) -> Path:
+    """Download one split of a parquet/webdataset-shard OSL dataset and
+    convert it to a local OSL v2 JSON with media extracted alongside it.
+
+    Thin wrapper around opensportslib.tools.hf_transfer.
+    download_dataset_split_from_hf(..., download_format="parquet"), which
+    itself does snapshot_download(allow_patterns=[f"{split}/*"]) -- for a
+    sharded dataset that's a handful of `metadata.parquet` /
+    `shard_manifest.parquet` / `shards/shard-*.tar` files (see
+    opensportslib/tools/parquet_to_osl_json.py for the exact expected
+    layout), not one request per sample, regardless of how many samples the
+    split has.
+    """
+    from opensportslib.tools.hf_transfer import download_dataset_split_from_hf
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    result = download_dataset_split_from_hf(
+        repo_id,
+        revision,
+        split,
+        str(output_dir),
+        download_format="parquet",
+        token=hf_token(),
+        progress_cb=lambda msg: report_step(f"[{repo_id}@{revision}:{split}] {msg}"),
+    )
+    return Path(result["json_path"])
+
+
+def prefer_osl_ready_dataset(
+    primary: str, fallback: str | None, *, primary_revision: str
+) -> tuple[str, str, bool]:
+    """Prefer `primary`@`primary_revision` (an OSL-ready/sharded dataset
+    branch) if it's populated; otherwise fall back to `fallback` (a
+    known-good, currently-populated but non-sharded dataset on its default
+    branch) and say why. Returns (repo_id, revision, is_sharded).
+
+    If `fallback` is None and `primary` isn't populated, skips the test --
+    use this when there's no non-sharded alternative worth falling back to.
+    """
+    if repo_is_populated(primary, revision=primary_revision):
+        return primary, primary_revision, True
+    if fallback is None:
+        require_repo_populated(primary, revision=primary_revision)  # raises pytest.skip
+    report_step(
+        f"{primary!r}@{primary_revision} (OSL-ready/sharded) is not populated "
+        f"yet -- falling back to {fallback!r}. Re-run once {primary!r}@"
+        f"{primary_revision} is published to automatically switch to the "
+        f"sharded version."
+    )
+    return fallback, "main", False
+
+
+def snapshot_dataset(
+    repo_id: str,
+    local_dir: Path,
+    *,
+    allow_patterns: list[str] | None = None,
+) -> Path:
+    """Download (or update) a full dataset repo, or a pattern-restricted
+    subset of it, into local_dir. Safe to call repeatedly (resumable)."""
+    from huggingface_hub import snapshot_download
+
+    local_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id=repo_id,
+        repo_type="dataset",
+        local_dir=str(local_dir),
+        token=hf_token(),
+        allow_patterns=allow_patterns,
+    )
+    return local_dir
+
+
+def download_files(repo_id: str, filenames: list[str], local_dir: Path) -> list[Path]:
+    from huggingface_hub import hf_hub_download
+
+    local_dir.mkdir(parents=True, exist_ok=True)
+    out = []
+    for filename in filenames:
+        path = hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            filename=filename,
+            local_dir=str(local_dir),
+            token=hf_token(),
+        )
+        out.append(Path(path))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Canonical config materialization
+#
+# opensportslib/configs/<task>/<name>.yaml files are NOT self-contained: the
+# library layers them on top of opensportslib/configs/default.yaml and
+# opensportslib/configs/<task>/default.yaml at load time (see
+# opensportslib/core/config/loader.py::_compose_yaml_layers), but only when
+# the path is physically inside opensportslib/configs/<task>/. We reuse the
+# library's own composer to get the real, maintained defaults, apply our
+# dataset/run overrides on top in Python, then write the fully-resolved
+# result out to CONFIG_DIR (outside opensportslib/configs/) so it loads as a
+# plain standalone config.
+# --------------------------------------------------------------------------
+
+
+def _deep_merge(base: Any, override: Any) -> Any:
+    if not isinstance(base, dict) or not isinstance(override, dict):
+        return deepcopy(override)
+    merged = deepcopy(base)
+    for key, value in override.items():
+        merged[key] = _deep_merge(merged.get(key), value) if key in merged else deepcopy(value)
+    return merged
+
+
+def materialize_config(task: str, name: str, overrides: dict, *, out_name: str | None = None) -> str:
+    """Load opensportslib/configs/<task>/<name>.yaml with its real defaults
+    applied, deep-merge `overrides` on top, write the result under
+    CONFIG_DIR, and return the path to the materialized file.
+    """
+    from opensportslib.core.config import load_config, save_config
+
+    canonical_path = REPO_ROOT / "opensportslib" / "configs" / task / f"{name}.yaml"
+    if not canonical_path.is_file():
+        raise FileNotFoundError(f"No such canonical config: {canonical_path}")
+
+    base = load_config(str(canonical_path), as_namespace=False, validate=False)
+    merged = _deep_merge(base, overrides)
+
+    out_path = CONFIG_DIR / (out_name or f"{task}_{name}.yaml")
+    save_config(merged, out_path)
+    return str(out_path)
+
+
+def system_block(run_name: str, *, gpu_count: int = 1) -> dict:
+    """Standard SYSTEM override pointing checkpoints/logs at OUTPUT_DIR."""
+    run_dir = OUTPUT_DIR / run_name
+    return {
+        "SYSTEM": {
+            "paths": {
+                "save_dir": str(run_dir / "checkpoints"),
+                "work_dir": str(run_dir),
+                "log_dir": str(run_dir / "logs"),
+            },
+            "device": "auto",
+            "gpu": {"count": gpu_count, "id": 0},
+            "reproducibility": {"use_seed": True, "seed": 0},
+        }
+    }
+
+
+def report_step(label: str) -> None:
+    print(f"\n=== {label} ===", flush=True)
+
+
+def classes_from_osl_json(payload: dict, *, head: str | None = None) -> list[str]:
+    """Extract a single_label head's class list from an OSL v2 JSON payload.
+    Defaults to the first label head found (fine for datasets with exactly
+    one classification/event head, which is the common case here); pass
+    `head` explicitly for multi-head datasets (e.g. OSL-XFoul's `action` +
+    `offence`).
+    """
+    labels = payload.get("labels") or {}
+    if not labels:
+        raise ValueError("No 'labels' block in this OSL v2 payload.")
+    key = head or next(iter(labels))
+    return list(labels[key]["labels"])

--- a/tests/release/test_classification_release.py
+++ b/tests/release/test_classification_release.py
@@ -1,0 +1,413 @@
+"""Release verification: ClassificationModel training across backbone families.
+
+Prefers OpenSportsLab/OSL-XFoul, pinned in the OpenSportsLab/osl-ready-
+datasets Hugging Face collection (parquet + webdataset shards). It's the
+dataset opensportslib/configs/classification/video.yaml's own data_root
+comment points at (dataset_name: mvfouls) and doubles as the VQA dataset
+(see test_vqa_release.py) -- same dual-purpose RefPal/MVFouls-style clips
+with both classification labels and referee Q&A. It's an unpublished
+placeholder as of the last check, so this falls back to
+OpenSportsLab/OSL-cls-UEFA-fouls (real, populated, gated: request access at
+https://huggingface.co/datasets/OpenSportsLab/OSL-cls-UEFA-fouls and export
+HF_TOKEN, or `hf auth login`, before running) until OSL-XFoul lands. Point
+OSL_RELEASE_CLS_REPO / OSL_RELEASE_CLS_FALLBACK_REPO at different repos to
+override either side.
+
+The fallback has been verified against real repo content (with granted
+access): it ships a proper OSL v2 `refpal_labels_processed.json` (top-level
+`data`/`labels` keys, `inputs: [{"type": "video", "path":
+"processed_videos/<id>.mp4"}]`) with two label heads -- `action` (18
+foul-type classes, used here) and `offence` (7-level severity, 0-6, not used
+here) -- so `_load_and_convert_labels` below takes its "already OSL v2" fast
+path unchanged. It's a small dataset (13 clips as of the last check), so
+treat this as a correctness spot-check across backbones, not a
+scale/accuracy benchmark. The list/dict-of-records conversion path in the
+same function is kept in case a differently-shaped dataset is swapped in via
+OSL_RELEASE_CLS_FALLBACK_REPO; if the upstream schema changes shape
+entirely, that function is the first place to look -- it fails with a clear
+assertion rather than guessing silently.
+
+Covers two backbone families dispatched by
+opensportslib/models/builder.py::build_model_canonical for TASK=classification:
+
+* MVNetwork family (video_encoder -> video_adapter -> task_head, provider
+  "torchvision"): r3d_18, mc3_18, r2plus1d_18, s3d, mvit_v2_s. Verified
+  end-to-end for r3d_18 against real downloaded video in a prior smoke test;
+  the others share the exact same code path and canonical config
+  (classification/video.yaml) and are expected to behave the same.
+* HuggingFace VideoMAE full-model path (encoder_type == "video_mae"):
+  included as best-effort — not verified this session.
+
+Not covered here (marked skip with a reason instead of a fake pass):
+* The VideoModel "frames_npy" family (dinov3, clip, videomae, videomae2 as
+  pure feature extractors) needs a pre-extraction step (raw video -> frame
+  .npy) that this suite does not implement yet. See the skipped test at the
+  bottom for the TODO.
+* Tracking-based classification (graph_conv / classification/sngar_tracking.yaml)
+  needs OpenSportsLab/SoccerNet-GAR, which is an unpublished placeholder repo
+  as of the last check (require_repo_populated will skip it cleanly; re-run
+  once it's populated).
+
+Run:
+    RUN_OSL_RELEASE_TESTS=1 HF_TOKEN=hf_xxx \\
+        pytest tests/release/test_classification_release.py -v -s
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from opensportslib.apis.classification import ClassificationModel
+
+from ._release_common import (
+    CACHE_ROOT,
+    DATA_DIR,
+    classes_from_osl_json,
+    download_shard_split,
+    epochs_for,
+    materialize_config,
+    max_items_for,
+    prefer_osl_ready_dataset,
+    report_step,
+    require_release_enabled,
+    require_repo_access,
+    require_repo_populated,
+    snapshot_dataset,
+    system_block,
+)
+
+# OSL-XFoul is pinned in the OpenSportsLab/osl-ready-datasets collection
+# (parquet + webdataset shards) and is the dataset
+# opensportslib/configs/classification/video.yaml's own data_root comment
+# points at (dataset_name: mvfouls) -- the same dual-purpose RefPal/MVFouls-
+# style dataset used for VQA (see test_vqa_release.py). Prefer it. Its
+# default ("main") branch is an empty placeholder; the real shards live on
+# the "224p"/"720p" branches (train/valid/test each) -- default to "224p"
+# (smaller/faster), override with OSL_RELEASE_CLS_REVISION=720p. Falls back
+# to OSL-cls-UEFA-fouls (real, populated, gated, verified against real
+# content with granted access -- see below) only if neither branch is up.
+CLS_PRIMARY_REPO = os.environ.get("OSL_RELEASE_CLS_REPO", "OpenSportsLab/OSL-XFoul")
+CLS_PRIMARY_REVISION = os.environ.get("OSL_RELEASE_CLS_REVISION", "224p")
+CLS_FALLBACK_REPO = os.environ.get("OSL_RELEASE_CLS_FALLBACK_REPO", "OpenSportsLab/OSL-cls-UEFA-fouls")
+TRACKING_CLS_REPO = os.environ.get("OSL_RELEASE_TRACKING_CLS_REPO", "OpenSportsLab/SoccerNet-GAR")
+
+os.environ.setdefault("WANDB_MODE", "disabled")
+os.environ.setdefault("OSL_PRETRAINED_WEIGHTS", "0")
+
+
+# --------------------------------------------------------------------------
+# Dataset prep
+# --------------------------------------------------------------------------
+
+
+def _resolve_label(record: dict) -> str | None:
+    for key in ("label", "action_class", "foul_type", "class", "action"):
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, dict) and isinstance(value.get("label"), str):
+            return value["label"]
+    return None
+
+
+def _resolve_id(record: dict, fallback_index: int) -> str:
+    for key in ("id", "action_id", "clip_id", "name"):
+        value = record.get(key)
+        if value is not None:
+            return str(value)
+    return f"clip_{fallback_index:05d}"
+
+
+def _resolve_video_relpath(record: dict, clip_id: str, videos_dir: Path) -> str | None:
+    for key in ("video", "clip", "file", "filename", "path"):
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            rel = value if "/" in value else f"processed_videos/{value}"
+            if (videos_dir.parent / rel).is_file():
+                return rel
+    guess = f"processed_videos/{clip_id}.mp4"
+    if (videos_dir.parent / guess).is_file():
+        return guess
+    return None
+
+
+def _load_and_convert_labels(root: Path, repo_id: str) -> dict:
+    """Best-effort conversion of the dataset's label file into OSL v2 JSON.
+
+    See the module docstring: this is the part most likely to need a fix if
+    the upstream schema has moved on since this was written.
+    """
+    label_files = list(root.glob("*labels*.json"))
+    assert label_files, (
+        f"No '*labels*.json' file found under {root}. Inspect the downloaded "
+        f"repo contents and update _load_and_convert_labels()."
+    )
+    raw = json.loads(label_files[0].read_text(encoding="utf-8"))
+
+    if isinstance(raw, dict) and "data" in raw:
+        # Already OSL v2 -- use as-is.
+        return raw
+
+    records = raw if isinstance(raw, list) else list(raw.values())
+    assert isinstance(records, list) and records, (
+        f"Unrecognized label file schema in {label_files[0].name}: expected a "
+        f"list of records, or a dict keyed by clip id, or an OSL v2 payload "
+        f"with a top-level 'data' key. Update _load_and_convert_labels()."
+    )
+
+    videos_dir = root / "processed_videos"
+    items = []
+    for idx, record in enumerate(records):
+        assert isinstance(record, dict), f"Expected dict records, got {type(record)}"
+        clip_id = _resolve_id(record, idx)
+        label = _resolve_label(record)
+        video_rel = _resolve_video_relpath(record, clip_id, videos_dir)
+        if label is None or video_rel is None:
+            continue
+        items.append(
+            {
+                "id": clip_id,
+                "inputs": [{"type": "video", "path": video_rel}],
+                "labels": {"action": {"label": label}},
+            }
+        )
+    assert items, (
+        f"Converted 0/{len(records)} label records to OSL v2 -- the field "
+        f"names in _resolve_label/_resolve_id/_resolve_video_relpath don't "
+        f"match this dataset's schema. Inspect {label_files[0]} and fix them."
+    )
+
+    classes = sorted({item["labels"]["action"]["label"] for item in items})
+    return {
+        "version": "2.0",
+        "task": "action_classification",
+        "dataset_name": repo_id,
+        "labels": {"action": {"type": "single_label", "labels": classes}},
+        "data": items,
+    }
+
+
+def _split_dataset(payload: dict, seed: int = 0) -> dict[str, dict]:
+    import random
+
+    items = list(payload["data"])
+    random.Random(seed).shuffle(items)
+    n = len(items)
+    n_train = max(1, int(n * 0.7))
+    n_valid = max(1, int(n * 0.15))
+    splits = {
+        "train": items[:n_train],
+        "valid": items[n_train : n_train + n_valid],
+        "test": items[n_train + n_valid :] or items[-1:],
+    }
+    return {
+        split: {**payload, "data": split_items} for split, split_items in splits.items()
+    }
+
+
+@pytest.fixture(scope="module")
+def classification_dataset():
+    require_release_enabled()
+    require_repo_access(CLS_PRIMARY_REPO)
+
+    repo_id, revision, is_sharded = prefer_osl_ready_dataset(
+        CLS_PRIMARY_REPO, fallback=CLS_FALLBACK_REPO, primary_revision=CLS_PRIMARY_REVISION
+    )
+
+    if is_sharded:
+        root = DATA_DIR / "classification" / f"{repo_id.split('/')[-1]}-{revision}"
+        split_paths = {
+            split: download_shard_split(repo_id, split, root, revision=revision)
+            for split in ("train", "valid", "test")
+        }
+        classes = classes_from_osl_json(json.loads(split_paths["test"].read_text(encoding="utf-8")), head="action")
+        return {"data_root": root, "classes": classes, "split_paths": split_paths}
+
+    # Fallback: known-good, real (gated) dataset -- not sharded, but small
+    # (13 clips), so downloaded and split locally rather than capped.
+    require_repo_access(repo_id)
+    root = DATA_DIR / "classification" / repo_id.split("/")[-1]
+    report_step(f"Downloading {repo_id} to {root}")
+    snapshot_dataset(repo_id, root)
+
+    payload = _load_and_convert_labels(root, repo_id)
+    splits = _split_dataset(payload)
+
+    split_dir = root / "_osl_v2_splits"
+    split_dir.mkdir(exist_ok=True)
+    split_paths = {}
+    for split, split_payload in splits.items():
+        path = split_dir / f"annotations-classification-{split}.json"
+        path.write_text(json.dumps(split_payload, indent=2), encoding="utf-8")
+        split_paths[split] = path
+
+    classes = payload["labels"]["action"]["labels"]
+    counts = Counter(item["labels"]["action"]["label"] for item in payload["data"])
+    print(f"Classes ({len(classes)}): {classes}")
+    print(f"Label distribution: {dict(counts)}")
+
+    return {
+        "data_root": root,
+        "classes": classes,
+        "split_paths": split_paths,
+    }
+
+
+# --------------------------------------------------------------------------
+# Backbone matrix
+# --------------------------------------------------------------------------
+
+# (backbone name, torchvision provider) for the MVNetwork family. All share
+# the same video_adapter (MV_Aggregate) / task_head (MV_LinearLayer) wiring.
+MVNETWORK_BACKBONES = ["r3d_18", "mc3_18", "r2plus1d_18", "s3d", "mvit_v2_s"]
+
+
+def _run_classification_pipeline(config_path: str, dataset: dict, run_name: str) -> None:
+    split_paths = dataset["split_paths"]
+
+    report_step(f"[{run_name}] instantiate ClassificationModel")
+    model = ClassificationModel(config=config_path, weights=None)
+
+    report_step(f"[{run_name}] train()")
+    checkpoint = model.train(
+        train_set=str(split_paths["train"]),
+        valid_set=str(split_paths["valid"]),
+        use_wandb=False,
+    )
+    assert checkpoint and Path(checkpoint).exists(), f"[{run_name}] checkpoint was not written"
+
+    report_step(f"[{run_name}] infer()")
+    predictions = model.infer(test_set=str(split_paths["test"]), weights=checkpoint, use_wandb=False)
+    assert isinstance(predictions, dict) and predictions.get("data"), f"[{run_name}] empty predictions"
+
+    report_step(f"[{run_name}] save_predictions()")
+    pred_path = CACHE_ROOT / "outputs" / f"classification_{run_name}_predictions.json"
+    model.save_predictions(output_path=str(pred_path), predictions=predictions)
+    assert pred_path.exists()
+
+    report_step(f"[{run_name}] evaluate()")
+    metrics = model.evaluate(test_set=str(split_paths["test"]), use_wandb=False)
+    assert isinstance(metrics, dict), f"[{run_name}] evaluate() did not return metrics"
+    print(f"[{run_name}] metrics: {metrics}")
+
+
+@pytest.mark.release
+@pytest.mark.parametrize("backbone", MVNETWORK_BACKBONES)
+def test_classification_mvnetwork_backbone(classification_dataset, backbone):
+    require_release_enabled()
+    dataset = classification_dataset
+    max_frames = max_items_for("OSL_RELEASE_CLS_NUM_FRAMES", 16)
+
+    overrides = system_block(f"classification_{backbone}")
+    overrides["DATA"] = {
+        "common": {
+            "dataset_name": dataset["data_root"].name,
+            "data_root": str(dataset["data_root"]),
+            "classes": dataset["classes"],
+            "splits": {
+                split: {
+                    "annotation_path": str(path),
+                    "source_path": str(dataset["data_root"]),
+                }
+                for split, path in dataset["split_paths"].items()
+            },
+        },
+        "inputs": {
+            "video": {
+                "sampling": {"num_frames": max_frames},
+                "params": {"view_type": "single", "num_classes": len(dataset["classes"])},
+            }
+        },
+    }
+    overrides["MODEL"] = {
+        "components": {
+            "video_encoder": {"source": {"name": backbone}, "params": {"pretrained_model": backbone}},
+            "task_head": {"params": {"num_classes": len(dataset["classes"])}},
+        }
+    }
+    overrides["TRAIN"] = {"epochs": epochs_for(2)}
+
+    config_path = materialize_config("classification", "video", overrides, out_name=f"cls_{backbone}.yaml")
+    _run_classification_pipeline(config_path, dataset, backbone)
+
+
+@pytest.mark.release
+def test_classification_video_mae_huggingface_backend(classification_dataset):
+    """Best-effort coverage of the HF VideoMAE full-model path
+    (encoder_type == 'video_mae' in build_model_canonical). Not verified
+    this session -- if it fails, check build_video_mae_backbone() in
+    opensportslib/models/base/video.py for what it actually expects from the
+    dataloader batch.
+    """
+    require_release_enabled()
+    dataset = classification_dataset
+
+    overrides = system_block("classification_video_mae")
+    overrides["DATA"] = {
+        "common": {
+            "dataset_name": dataset["data_root"].name,
+            "data_root": str(dataset["data_root"]),
+            "classes": dataset["classes"],
+            "splits": {
+                split: {
+                    "annotation_path": str(path),
+                    "source_path": str(dataset["data_root"]),
+                }
+                for split, path in dataset["split_paths"].items()
+            },
+        },
+        "inputs": {
+            "video": {
+                "params": {"view_type": "single", "num_classes": len(dataset["classes"])},
+            }
+        },
+    }
+    overrides["MODEL"] = {
+        "components": {
+            "video_encoder": {
+                "source": {"provider": "opensportslib", "registry": "backbone", "name": "video_mae"},
+                "params": {"pretrained_model": "MCG-NJU/videomae-base"},
+            },
+            "task_head": {"params": {"num_classes": len(dataset["classes"])}},
+        }
+    }
+    overrides["TRAIN"] = {"epochs": epochs_for(2)}
+
+    config_path = materialize_config("classification", "video", overrides, out_name="cls_video_mae.yaml")
+    _run_classification_pipeline(config_path, dataset, "video_mae")
+
+
+@pytest.mark.release
+def test_classification_tracking_graph_conv():
+    """Tracking-modality classification (graph_conv backbone,
+    classification/sngar_tracking.yaml canonical config). Uses
+    OpenSportsLab/SoccerNet-GAR, which is an unpublished placeholder repo as
+    of the last check -- this cleanly skips until it is populated.
+    """
+    require_release_enabled()
+    require_repo_populated(TRACKING_CLS_REPO)
+    pytest.skip(
+        "SoccerNet-GAR is now populated but this test body still needs to be "
+        "written: download the tracking-parquet splits and point "
+        "classification/sngar_tracking.yaml's DATA.common.data_root at them "
+        "(same pattern as the video-backbone tests above)."
+    )
+
+
+@pytest.mark.release
+@pytest.mark.skip(
+    reason=(
+        "The VideoModel 'frames_npy' family (dinov3/clip/videomae/videomae2 as "
+        "pure feature extractors, see opensportslib/models/base/video.py) needs "
+        "a raw-video -> frame-.npy pre-extraction step this suite doesn't "
+        "implement yet. Wire that up, then flesh this test out following the "
+        "MVNetwork parametrization above."
+    )
+)
+def test_classification_frames_npy_backbones():
+    pass

--- a/tests/release/test_localization_release.py
+++ b/tests/release/test_localization_release.py
@@ -1,0 +1,386 @@
+"""Release verification: LocalizationModel training across model families.
+
+Each dataset fixture prefers a dataset pinned in the
+OpenSportsLab/osl-ready-datasets Hugging Face collection -- the org's
+sharded (parquet + webdataset) datasets, a handful of large files per split
+rather than one file per clip/game -- and falls back to a known-good, real,
+but loose-file dataset only while the sharded one isn't populated yet (see
+_release_common.prefer_osl_ready_dataset()). Both OSL-ready repos below are
+unpublished placeholders as of the last check, so both fixtures currently
+take the fallback path; re-run after either lands to switch automatically.
+
+* Primary: OpenSportsLab/OSL-SNBAS. Fallback:
+  OpenSportsLab/soccernetpro-localization-tennis (real, public, 3450 loose
+  files, capped by default -- see OSL_RELEASE_MAX_CLIPS). Drives the E2E
+  family (opensportslib/configs/localization/video_ocv.yaml, and
+  video_dali.yaml if the `nvidia.dali` optional dependency is installed)
+  across a curated backbone x head matrix. OSL-SNBAS is exactly the dataset
+  video_ocv.yaml was written for (same 12-class Ball Action Spotting label
+  set, same model-zoo checkpoints OSL-loc-snbas-2023-e2e /
+  OSL-loc-snbas-2025-e2e); the tennis fallback + rn18/gru combo was verified
+  end-to-end in a prior smoke-test session (see git history around the
+  ResnetExtractFeatures fix in opensportslib/models/backbones/builder.py) --
+  the other backbones/heads share that exact code path.
+
+* Primary: OpenSportsLab/OSL-SoccerNet. Fallback:
+  OpenSportsLab/SoccerNet-ActionSpotting-Features (real, public, 2210 loose
+  ResNET_TF2_PCA512 feature files in a `ResNET_PCA512/<split>/...` +
+  per-split `annotations.json` layout, capped by default -- see
+  OSL_RELEASE_MAX_GAMES). Drives the classic ContextAware (CALF) and
+  LearnablePooling (NetVLAD++) families, matching
+  opensportslib/configs/localization/calf_resnetpca512.yaml and
+  netvladpp_resnetpca512.yaml's own 17-class SoccerNet Action Spotting label
+  set. Not verified end-to-end this session (the E2E/tennis path was); if a
+  schema (either OSL-SoccerNet's shards, or the fallback's annotations.json)
+  has moved on, that's the first place to check.
+
+Run:
+    RUN_OSL_RELEASE_TESTS=1 pytest tests/release/test_localization_release.py -v -s
+
+    # bigger (but still capped) fallback subsets:
+    RUN_OSL_RELEASE_TESTS=1 OSL_RELEASE_MAX_CLIPS=200 OSL_RELEASE_MAX_GAMES=50 \\
+        pytest tests/release/test_localization_release.py -v -s
+
+    # full-scale fallback feature dataset (~111GB, 2210 individual files):
+    RUN_OSL_RELEASE_TESTS=1 OSL_RELEASE_MAX_GAMES=all \\
+        pytest tests/release/test_localization_release.py -k feature -v -s
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from opensportslib.apis.localization import LocalizationModel
+
+from ._release_common import (
+    CACHE_ROOT,
+    DATA_DIR,
+    classes_from_osl_json,
+    download_files,
+    download_shard_split,
+    epochs_for,
+    hf_token,
+    materialize_config,
+    max_items_for,
+    optional_module_available,
+    prefer_osl_ready_dataset,
+    report_step,
+    require_release_enabled,
+    require_repo_access,
+    snapshot_dataset,
+    system_block,
+)
+
+# OSL-SNBAS is pinned in the OpenSportsLab/osl-ready-datasets collection
+# (parquet + webdataset shards) and is exactly the dataset
+# opensportslib/configs/localization/video_ocv.yaml was written for -- same
+# 12-class Ball Action Spotting label set, same model-zoo checkpoints
+# (OSL-loc-snbas-2023-e2e / OSL-loc-snbas-2025-e2e). Prefer it. Its default
+# ("main") branch is an empty placeholder; the real shards live on
+# "{224p,720p}-{2023,2024}" branches (train/valid/test/challenge each) --
+# default to "224p-2024" (smallest, most recent), override with
+# OSL_RELEASE_LOC_E2E_REVISION. Falls back to the tennis dataset (real,
+# populated, loose files) only if that branch isn't up either.
+#
+# OSL-SoccerNet (below) *also* has "224p"/"720p" raw-video branches -- the
+# classic 17-class SoccerNet Action Spotting task rather than SNBAS's
+# 12-class Ball Action Spotting -- which work just as well for this E2E
+# family. To use those instead, point OSL_RELEASE_LOC_E2E_REPO at
+# OpenSportsLab/OSL-SoccerNet and OSL_RELEASE_LOC_E2E_REVISION at "224p" or
+# "720p"; _e2e_overrides() derives its class list from the downloaded data
+# either way, so no other change is needed.
+E2E_PRIMARY_REPO = os.environ.get("OSL_RELEASE_LOC_E2E_REPO", "OpenSportsLab/OSL-SNBAS")
+E2E_PRIMARY_REVISION = os.environ.get("OSL_RELEASE_LOC_E2E_REVISION", "224p-2024")
+E2E_FALLBACK_REPO = os.environ.get("OSL_RELEASE_LOC_E2E_FALLBACK_REPO", "OpenSportsLab/soccernetpro-localization-tennis")
+
+# OSL-SoccerNet is the other localization dataset pinned in the OSL-ready
+# collection. Its "ResNET_PCA512" branch ships classic 17-class SoccerNet
+# Action Spotting as pre-extracted features, matching calf_resnetpca512.yaml
+# / netvladpp_resnetpca512.yaml's own class list -- prefer it. Falls back to
+# the (non-sharded, 2210-file) SoccerNet-ActionSpotting-Features dataset only
+# if that branch isn't up.
+FEATURES_PRIMARY_REPO = os.environ.get("OSL_RELEASE_LOC_FEATURES_REPO", "OpenSportsLab/OSL-SoccerNet")
+FEATURES_PRIMARY_REVISION = os.environ.get("OSL_RELEASE_LOC_FEATURES_REVISION", "ResNET_PCA512")
+FEATURES_FALLBACK_REPO = os.environ.get(
+    "OSL_RELEASE_LOC_FEATURES_FALLBACK_REPO", "OpenSportsLab/SoccerNet-ActionSpotting-Features"
+)
+
+os.environ.setdefault("WANDB_MODE", "disabled")
+os.environ.setdefault("OSL_PRETRAINED_WEIGHTS", "0")
+
+
+# --------------------------------------------------------------------------
+# E2E raw-video dataset prep
+# --------------------------------------------------------------------------
+
+TENNIS_CLASSES = [
+    "far_court_bounce", "far_court_serve", "far_court_swing",
+    "near_court_bounce", "near_court_serve", "near_court_swing",
+]
+
+
+@pytest.fixture(scope="module")
+def e2e_localization_dataset():
+    require_release_enabled()
+    require_repo_access(E2E_PRIMARY_REPO)
+
+    repo_id, revision, is_sharded = prefer_osl_ready_dataset(
+        E2E_PRIMARY_REPO, fallback=E2E_FALLBACK_REPO, primary_revision=E2E_PRIMARY_REVISION
+    )
+
+    if is_sharded:
+        root = DATA_DIR / "localization" / f"{repo_id.split('/')[-1]}-{revision}"
+        split_paths = {
+            split: download_shard_split(repo_id, split, root, revision=revision)
+            for split in ("train", "valid", "test")
+        }
+        classes = classes_from_osl_json(json.loads(split_paths["test"].read_text(encoding="utf-8")))
+        return {"data_root": root, "split_paths": split_paths, "classes": classes}
+
+    # Fallback: known-good, real, but loose-file dataset. Capped by default
+    # (the repo is 3450 individual files) -- set OSL_RELEASE_MAX_CLIPS=all
+    # for the full ~1.4GB dataset.
+    require_repo_access(repo_id)
+    root = DATA_DIR / "localization" / "tennis"
+    max_clips = max_items_for("OSL_RELEASE_MAX_CLIPS", 40)
+
+    if max_clips is None:
+        report_step(f"Downloading full {repo_id} to {root}")
+        snapshot_dataset(repo_id, root)
+        split_paths = {
+            split: root / f"annotations-localization-{split}.json"
+            for split in ("train", "valid", "test")
+        }
+    else:
+        report_step(f"Downloading {repo_id} annotations + {max_clips} clips/split to {root}")
+        root.mkdir(parents=True, exist_ok=True)
+        split_paths = {}
+        for split in ("train", "valid", "test"):
+            full = download_files(repo_id, [f"annotations-localization-{split}.json"], root)[0]
+            payload = json.loads(full.read_text(encoding="utf-8"))
+            entries = [e for e in payload["data"] if e.get("events")][:max_clips]
+            video_files = [
+                inp["path"] for e in entries for inp in e["inputs"] if inp["type"] == "video"
+            ]
+            download_files(repo_id, video_files, root)
+            subset_path = root / f"annotations-localization-{split}.json"
+            subset_path.write_text(json.dumps({**payload, "data": entries}, indent=2), encoding="utf-8")
+            split_paths[split] = subset_path
+
+    return {"data_root": root, "split_paths": split_paths, "classes": TENNIS_CLASSES}
+
+
+def _e2e_overrides(run_name: str, dataset: dict, backbone: str, head: str, *, loader_backend: str = "opencv") -> dict:
+    root = dataset["data_root"]
+    split_paths = dataset["split_paths"]
+    overrides = system_block(f"localization_{run_name}")
+    overrides["DATA"] = {
+        "common": {
+            "dataset_name": root.name,
+            "data_root": str(root),
+            "classes": dataset["classes"],
+            "runtime": {"loader_backend": loader_backend},
+            "splits": {
+                "train": {"annotation_path": str(split_paths["train"]), "source_path": str(root)},
+                "valid": {"annotation_path": str(split_paths["valid"]), "source_path": str(root)},
+                "valid_data_frames": {"annotation_path": str(split_paths["valid"]), "source_path": str(root)},
+                "test": {
+                    "annotation_path": str(split_paths["test"]),
+                    "source_path": str(root),
+                    "results": str(CACHE_ROOT / "outputs" / f"localization_{run_name}_results"),
+                    # overlap_len must stay < clip_len or ActionSpotVideoDataset
+                    # builds an empty clip window (see the negative-step range
+                    # bug worked around in the earlier smoke test).
+                    "overlap_len": 0,
+                },
+            },
+        },
+    }
+    overrides["MODEL"] = {
+        "components": {
+            "video_encoder": {"source": {"name": backbone}},
+            "task_head": {"source": {"name": head}},
+        }
+    }
+    overrides["TRAIN"] = {
+        "epochs": epochs_for(2),
+        "scheduler": {"num_epochs": epochs_for(2)},
+    }
+    return overrides
+
+
+def _run_localization_pipeline(config_path: str, dataset: dict, run_name: str) -> None:
+    split_paths = dataset["split_paths"]
+
+    report_step(f"[{run_name}] instantiate LocalizationModel")
+    model = LocalizationModel(config=config_path, weights=None)
+
+    report_step(f"[{run_name}] train()")
+    checkpoint = model.train(
+        train_set=str(split_paths["train"]),
+        valid_set=str(split_paths["valid"]),
+        use_wandb=False,
+    )
+    assert checkpoint and Path(checkpoint).exists(), f"[{run_name}] checkpoint was not written"
+
+    report_step(f"[{run_name}] infer()")
+    predictions = model.infer(test_set=str(split_paths["test"]), weights=checkpoint, use_wandb=False)
+    assert isinstance(predictions, dict) and predictions.get("data"), f"[{run_name}] empty predictions"
+
+    report_step(f"[{run_name}] save_predictions()")
+    pred_path = CACHE_ROOT / "outputs" / f"localization_{run_name}_predictions.json"
+    model.save_predictions(output_path=str(pred_path), predictions=predictions)
+    assert pred_path.exists()
+
+    report_step(f"[{run_name}] evaluate()")
+    metrics = model.evaluate(test_set=str(split_paths["test"]), use_wandb=False)
+    print(f"[{run_name}] metrics: {metrics}")
+
+
+# Curated backbone x head coverage. Full cross product of every
+# backbone_type/head_type check_config() allows (see opensportslib/core/utils/
+# load_annotations.py::check_config) would be 9 backbones x 4 heads = 36 runs;
+# this picks a representative subset that touches every backbone family and
+# every head at least once. Expand BACKBONES_TO_TEST / HEADS_TO_TEST for full
+# coverage on a dedicated release-test machine.
+E2E_BACKBONES = ["rn18", "rn50", "rny002", "rny008_gsm", "convnextt"]
+E2E_HEADS = ["gru", "deeper_gru", "mstcn", "asformer"]
+E2E_MATRIX = [(b, "gru") for b in E2E_BACKBONES] + [("rn18", h) for h in E2E_HEADS if h != "gru"]
+
+
+@pytest.mark.release
+@pytest.mark.parametrize("backbone,head", E2E_MATRIX, ids=[f"{b}-{h}" for b, h in E2E_MATRIX])
+def test_localization_e2e_opencv(e2e_localization_dataset, backbone, head):
+    require_release_enabled()
+    run_name = f"{backbone}_{head}_opencv"
+    overrides = _e2e_overrides(run_name, e2e_localization_dataset, backbone, head, loader_backend="opencv")
+    config_path = materialize_config("localization", "video_ocv", overrides, out_name=f"loc_{run_name}.yaml")
+    _run_localization_pipeline(config_path, e2e_localization_dataset, run_name)
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not optional_module_available("nvidia.dali"),
+    reason="DALI backend not installed; run `opensportslib setup --dali` first.",
+)
+def test_localization_e2e_dali(e2e_localization_dataset):
+    require_release_enabled()
+    run_name = "rny008_gsm_gru_dali"
+    overrides = _e2e_overrides(run_name, e2e_localization_dataset, "rny008_gsm", "gru", loader_backend="dali")
+    config_path = materialize_config("localization", "video_dali", overrides, out_name=f"loc_{run_name}.yaml")
+    _run_localization_pipeline(config_path, e2e_localization_dataset, run_name)
+
+
+# --------------------------------------------------------------------------
+# Feature-based classic models (CALF / NetVLAD++) on real SoccerNet features
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def features_dataset():
+    require_release_enabled()
+    require_repo_access(FEATURES_PRIMARY_REPO)
+
+    repo_id, revision, is_sharded = prefer_osl_ready_dataset(
+        FEATURES_PRIMARY_REPO, fallback=FEATURES_FALLBACK_REPO, primary_revision=FEATURES_PRIMARY_REVISION
+    )
+
+    if is_sharded:
+        root = DATA_DIR / "localization" / f"{repo_id.split('/')[-1]}-{revision}"
+        split_paths = {
+            split: download_shard_split(repo_id, split, root, revision=revision)
+            for split in ("train", "valid", "test")
+        }
+        classes = classes_from_osl_json(json.loads(split_paths["test"].read_text(encoding="utf-8")))
+        return {"data_root": root, "split_paths": split_paths, "classes": classes}
+
+    # Fallback: known-good, real, but loose-file dataset (2210 individual
+    # files) -- capped to OSL_RELEASE_MAX_GAMES games/split by default.
+    require_repo_access(repo_id)
+    root = DATA_DIR / "localization" / "soccernet_features"
+    max_games = max_items_for("OSL_RELEASE_MAX_GAMES", 10)
+
+    root.mkdir(parents=True, exist_ok=True)
+    split_paths = {}
+    for split in ("train", "valid", "test"):
+        split_dir = root / "ResNET_PCA512" / split
+        ann_path = download_files(
+            repo_id, [f"ResNET_PCA512/{split}/annotations.json"], root
+        )[0]
+        payload = json.loads(ann_path.read_text(encoding="utf-8"))
+
+        videos_by_game: dict[str, list[dict]] = defaultdict(list)
+        for video in payload["videos"]:
+            game = str(Path(video["path"]).parent)
+            videos_by_game[game].append(video)
+
+        games = list(videos_by_game)[: max_games] if max_games is not None else list(videos_by_game)
+        kept_videos = [v for game in games for v in videos_by_game[game]]
+
+        npy_paths = [f"ResNET_PCA512/{split}/{v['path']}" for v in kept_videos]
+        report_step(f"Downloading {len(npy_paths)} feature files for split={split} ({len(games)} games)")
+        download_files(repo_id, npy_paths, root)
+
+        subset_path = split_dir / "annotations.json"
+        subset_path.write_text(json.dumps({**payload, "videos": kept_videos}, indent=2), encoding="utf-8")
+        split_paths[split] = subset_path
+
+    classes = json.loads(split_paths["test"].read_text(encoding="utf-8"))["labels"]
+    return {"data_root": root, "split_paths": split_paths, "classes": classes}
+
+
+def _feature_family_overrides(run_name: str, dataset: dict) -> dict:
+    split_paths = dataset["split_paths"]
+    overrides = system_block(f"localization_{run_name}")
+    overrides["DATA"] = {
+        "common": {
+            "dataset_name": dataset["data_root"].name,
+            # Informational only -- each split below sets its own
+            # source_path explicitly, since the sharded and loose-file
+            # fallback layouts don't share a single common root.
+            "data_root": str(split_paths["train"].parent),
+            "classes": dataset["classes"],
+            "splits": {
+                "train": {
+                    "annotation_path": str(split_paths["train"]),
+                    "source_path": str(split_paths["train"].parent),
+                },
+                "valid": {
+                    "annotation_path": str(split_paths["valid"]),
+                    "source_path": str(split_paths["valid"].parent),
+                },
+                "test": {
+                    "annotation_path": str(split_paths["test"]),
+                    "source_path": str(split_paths["test"].parent),
+                    "results": str(CACHE_ROOT / "outputs" / f"localization_{run_name}_results"),
+                },
+            },
+        },
+    }
+    overrides["TRAIN"] = {"epochs": epochs_for(3)}
+    return overrides
+
+
+@pytest.mark.release
+def test_localization_calf_contextaware(features_dataset):
+    require_release_enabled()
+    overrides = _feature_family_overrides("calf", features_dataset)
+    config_path = materialize_config(
+        "localization", "calf_resnetpca512", overrides, out_name="loc_calf.yaml"
+    )
+    _run_localization_pipeline(config_path, features_dataset, "calf")
+
+
+@pytest.mark.release
+def test_localization_netvladpp_learnablepooling(features_dataset):
+    require_release_enabled()
+    overrides = _feature_family_overrides("netvladpp", features_dataset)
+    config_path = materialize_config(
+        "localization", "netvladpp_resnetpca512", overrides, out_name="loc_netvladpp.yaml"
+    )
+    _run_localization_pipeline(config_path, features_dataset, "netvladpp")

--- a/tests/release/test_vqa_release.py
+++ b/tests/release/test_vqa_release.py
@@ -1,0 +1,188 @@
+"""Release verification: VQAModel LoRA training across backends.
+
+Dataset: OpenSportsLab/OSL-XFoul -- the dataset behind every VQA checkpoint
+in the model zoo (OSL-VQA-XFOUL-XVARS-lora, OSL-VQA-XFOUL-qwen2.5-7B-VL-lora,
+OSL-VQA-XFOUL-qwen3-8B-VL-lora). It's one of the three datasets pinned in the
+OpenSportsLab/osl-ready-datasets Hugging Face collection, which the org
+publishes as parquet + webdataset shards (a handful of large files per split,
+not one file per sample) specifically so consumers don't need to pull
+thousands of individual clips one at a time.
+
+Like the other two OSL-ready repos, OSL-XFoul's default ("main") branch is an
+empty placeholder -- the real data lives on named branches: "224p" and
+"720p" (train/valid/test shards each). This module defaults to "224p"
+(smaller/faster); override with OSL_RELEASE_VQA_REVISION=720p for the
+higher-resolution branch. There's no non-sharded fallback dataset for VQA in
+the org, so unlike the classification/localization fixtures this one has
+nothing to fall back to -- it's OSL-XFoul@<revision> or skip.
+
+download_shard_split() (in _release_common.py) downloads and converts each
+split via opensportslib.tools.hf_transfer.download_dataset_split_from_hf(...,
+download_format="parquet"), which expects the `<split>/metadata.parquet` +
+`<split>/shard_manifest.parquet` + `<split>/shards/shard-*.tar` layout (see
+opensportslib/tools/parquet_to_osl_json.py) and converts it back to a local
+OSL v2 JSON with media extracted -- confirmed to match OSL-XFoul's real
+branch layout.
+
+Backends covered, each via its real canonical config
+(opensportslib/configs/vqa/*.yaml) with TRAIN.execution.training_backend
+already set correctly by that file's own defaults:
+
+* xvars       -- X-VARS / VideoChatGPT + LoRA (configs/vqa/xvars.yaml).
+                 Requires `opensportslib setup --vqa_xvars`.
+* qwen_lora   -- CLIP features + Qwen LoRA (configs/vqa/qwen_lora.yaml).
+                 Requires `opensportslib setup --vqa_qwen`.
+* qwen3_vl_native -- full end-to-end QwenVL LoRA (configs/vqa/qwen3_vl_native.yaml).
+                 Heaviest (downloads an 8B-parameter VLM). Requires
+                 `opensportslib setup --vqa_qwen`.
+
+Each test imports its backend's runtime module lazily and skips with the
+actual ImportError message if the optional dependency profile hasn't been
+installed, rather than guessing package names up front.
+
+Run:
+    RUN_OSL_RELEASE_TESTS=1 pytest tests/release/test_vqa_release.py -v -s
+
+    # higher-resolution branch:
+    RUN_OSL_RELEASE_TESTS=1 OSL_RELEASE_VQA_REVISION=720p \\
+        pytest tests/release/test_vqa_release.py -v -s
+
+    # skip the heaviest backend:
+    RUN_OSL_RELEASE_TESTS=1 pytest tests/release/test_vqa_release.py -v -s \\
+        -k "not qwen3_vl_native"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from opensportslib.apis.vqa import VQAModel
+
+from ._release_common import (
+    CACHE_ROOT,
+    DATA_DIR,
+    download_shard_split,
+    epochs_for,
+    materialize_config,
+    prefer_osl_ready_dataset,
+    report_step,
+    require_release_enabled,
+    require_repo_access,
+    system_block,
+)
+
+XFOUL_REPO = os.environ.get("OSL_RELEASE_VQA_REPO", "OpenSportsLab/OSL-XFoul")
+XFOUL_REVISION = os.environ.get("OSL_RELEASE_VQA_REVISION", "224p")
+
+os.environ.setdefault("WANDB_MODE", "disabled")
+
+
+@pytest.fixture(scope="module")
+def xfoul_dataset():
+    require_release_enabled()
+    require_repo_access(XFOUL_REPO)
+
+    repo_id, revision, is_sharded = prefer_osl_ready_dataset(
+        XFOUL_REPO, fallback=None, primary_revision=XFOUL_REVISION
+    )
+    assert is_sharded  # fallback=None means we only ever get here via the primary
+
+    root = DATA_DIR / "vqa" / f"OSL-XFoul-{revision}"
+    split_paths = {}
+    for split in ("train", "valid", "test"):
+        split_paths[split] = download_shard_split(repo_id, split, root, revision=revision)
+        payload = json.loads(split_paths[split].read_text(encoding="utf-8"))
+        print(f"{split}: {len(payload.get('data', []))} samples -> {split_paths[split]}")
+
+    return {"data_root": root, "split_paths": split_paths}
+
+
+def _run_vqa_pipeline(config_path: str, dataset: dict, run_name: str) -> None:
+    split_paths = dataset["split_paths"]
+
+    report_step(f"[{run_name}] instantiate VQAModel")
+    model = VQAModel(config=config_path, weights=None)
+
+    report_step(f"[{run_name}] train() (LoRA)")
+    checkpoint = model.train(
+        train_set=str(split_paths["train"]),
+        valid_set=str(split_paths["valid"]),
+        use_wandb=False,
+    )
+    assert checkpoint, f"[{run_name}] train() did not return a checkpoint"
+
+    report_step(f"[{run_name}] infer()")
+    predictions = model.infer(test_set=str(split_paths["test"]), weights=checkpoint, use_wandb=False)
+    assert isinstance(predictions, dict) and predictions.get("data"), f"[{run_name}] empty predictions"
+
+    report_step(f"[{run_name}] save_predictions()")
+    pred_path = CACHE_ROOT / "outputs" / f"vqa_{run_name}_predictions.json"
+    model.save_predictions(output_path=str(pred_path), predictions=predictions)
+    assert pred_path.exists()
+
+    report_step(f"[{run_name}] evaluate()")
+    metrics = model.evaluate(test_set=str(split_paths["test"]), predictions=predictions, use_wandb=False)
+    print(f"[{run_name}] metrics: {metrics}")
+
+
+def _dataset_overrides(run_name: str, dataset: dict) -> dict:
+    overrides = system_block(f"vqa_{run_name}", gpu_count=1)
+    split_paths = dataset["split_paths"]
+    overrides["DATA"] = {
+        "common": {
+            "dataset_name": "OSL-XFoul",
+            "data_root": str(dataset["data_root"]),
+            "splits": {
+                split: {"annotation_path": str(path), "source_path": str(dataset["data_root"])}
+                for split, path in split_paths.items()
+            },
+        }
+    }
+    overrides["TRAIN"] = {"epochs": epochs_for(1)}
+    return overrides
+
+
+@pytest.mark.release
+def test_vqa_xvars_videochatgpt_lora(xfoul_dataset):
+    require_release_enabled()
+    try:
+        import peft  # noqa: F401
+    except ImportError as exc:
+        pytest.skip(f"X-VARS LoRA deps not installed (run `opensportslib setup --vqa_xvars` first): {exc}")
+
+    overrides = _dataset_overrides("xvars", xfoul_dataset)
+    config_path = materialize_config("vqa", "xvars", overrides, out_name="vqa_xvars.yaml")
+    _run_vqa_pipeline(config_path, xfoul_dataset, "xvars")
+
+
+@pytest.mark.release
+def test_vqa_clip_qwen_lora(xfoul_dataset):
+    require_release_enabled()
+    try:
+        import peft  # noqa: F401
+    except ImportError as exc:
+        pytest.skip(f"Qwen LoRA deps not installed (run `opensportslib setup --vqa_qwen` first): {exc}")
+
+    overrides = _dataset_overrides("qwen_lora", xfoul_dataset)
+    config_path = materialize_config("vqa", "qwen_lora", overrides, out_name="vqa_qwen_lora.yaml")
+    _run_vqa_pipeline(config_path, xfoul_dataset, "qwen_lora")
+
+
+@pytest.mark.release
+@pytest.mark.slow
+def test_vqa_qwen3_vl_native_lora(xfoul_dataset):
+    """Heaviest backend: downloads an 8B-parameter end-to-end VLM."""
+    require_release_enabled()
+    try:
+        import peft  # noqa: F401
+    except ImportError as exc:
+        pytest.skip(f"Qwen VL native LoRA deps not installed (run `opensportslib setup --vqa_qwen` first): {exc}")
+
+    overrides = _dataset_overrides("qwen3_vl_native", xfoul_dataset)
+    config_path = materialize_config(
+        "vqa", "qwen3_vl_native", overrides, out_name="vqa_qwen3_vl_native.yaml"
+    )
+    _run_vqa_pipeline(config_path, xfoul_dataset, "qwen3_vl_native")


### PR DESCRIPTION
## Summary\n- add opt-in release verification tests for classification, localization, and VQA\n- add shared dataset/config/cache helpers and a guarded runner script\n- add SGD optimizer support and align ResNet extractors with the shared base class\n- ignore generated release-test cache output\n\n## Testing\n-  passed\n-  and  could not run because pytest is not installed in the active environment