### PR TITLE
feat: preserve Xet downloads with byte progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,13 @@ total_bytes)`. When the repository file is Xet-backed, OpenSportsLib keeps the
 accelerated Xet transfer and adapts Xet's byte updates to this callback. It
 falls back to classic HTTP progress when Xet is unavailable, disabled, or not
 used by the file.
+When byte progress is enabled, Parquet downloads also emit `[current/total]`
+file messages through `progress_cb` so clients can present file-count progress.
+High-level split downloads also accept `file_plan_cb(filenames)`,
+`file_completed_cb(filename, local_path)`, and
+`json_ready_cb(split, json_path)`. These are transfer lifecycle notifications;
+callers remain responsible for queue policy and presentation. For non-dry-run
+JSON datasets, pinned source metadata is persisted before `json_ready_cb` runs.
 
 JSON uploads support partially downloaded datasets: the JSON and all
 referenced files available locally are committed, while missing referenced

--- a/README.md
+++ b/README.md
@@ -356,6 +356,12 @@ The JSON records the resolved Hugging Face commit and can later be passed to
 Parquet/WebDataset download always completes the local split even when a
 metadata-only `<split>.json` already exists.
 
+Download APIs accept `byte_progress_cb(filename, downloaded_bytes,
+total_bytes)`. When the repository file is Xet-backed, OpenSportsLib keeps the
+accelerated Xet transfer and adapts Xet's byte updates to this callback. It
+falls back to classic HTTP progress when Xet is unavailable, disabled, or not
+used by the file.
+
 JSON uploads support partially downloaded datasets: the JSON and all
 referenced files available locally are committed, while missing referenced
 files are skipped and reported. Remote files not included in that commit are

--- a/docs/tools/hf-dataset-transfer.md
+++ b/docs/tools/hf-dataset-transfer.md
@@ -166,6 +166,19 @@ transfer with classic HTTP. If Xet is unavailable, explicitly disabled, or not
 used by the remote file, the same callback is driven by the HTTP fallback.
 Files are written to an atomic temporary path and moved into place only after
 completion. A total of `0` means that the remote size is unknown.
+For full Parquet downloads, `progress_cb` also receives a
+`[current/total] Downloading <path>` message before each repository file.
+
+The split download APIs additionally expose three low-level lifecycle hooks:
+
+- `file_plan_cb(filenames)` reports newly discovered repository files.
+- `file_completed_cb(filename, local_path)` reports an atomically completed
+  file.
+- `json_ready_cb(split, json_path)` reports that a usable JSON—with pinned
+  source metadata for non-dry-run JSON downloads—is available.
+
+These callbacks report transfer facts only. Scheduling, queue state, UI labels,
+and user prompts belong to the calling application.
 
 ## Upload
 

--- a/docs/tools/hf-dataset-transfer.md
+++ b/docs/tools/hf-dataset-transfer.md
@@ -160,9 +160,12 @@ directory collisions—are rejected.
 Both split download APIs and `download_dataset_sample_inputs_from_hf` accept an
 optional `byte_progress_cb(filename, downloaded_bytes, total_bytes)` callback.
 It is called while each remote file is transferring, allowing clients to show
-file-size progress instead of only item or split counts. When this callback is
-provided, files are streamed to an atomic temporary path and moved into place
-only after completion. A total of `0` means that the remote size is unknown.
+file-size progress instead of only item or split counts. For Xet-backed files,
+the callback receives Xet's byte increments without replacing the accelerated
+transfer with classic HTTP. If Xet is unavailable, explicitly disabled, or not
+used by the remote file, the same callback is driven by the HTTP fallback.
+Files are written to an atomic temporary path and moved into place only after
+completion. A total of `0` means that the remote size is unknown.
 
 ## Upload
 

--- a/opensportslib/tools/hf_transfer.py
+++ b/opensportslib/tools/hf_transfer.py
@@ -9,6 +9,9 @@ from typing import Any, Callable
 
 ProgressCallback = Callable[[str], None]
 ByteProgressCallback = Callable[[str, int, int], None]
+FilePlanCallback = Callable[[list[str]], None]
+FileCompletedCallback = Callable[[str, str], None]
+JsonReadyCallback = Callable[[str, str], None]
 CancelCheck = Callable[[], bool]
 
 HF_REPO_ID_KEY = "hf_repo_id"
@@ -99,6 +102,29 @@ def convert_parquet_metadata_to_json(*args, **kwargs):
 def _emit_progress(progress_cb: ProgressCallback | None, message: str) -> None:
     if progress_cb:
         progress_cb(message)
+
+
+def _emit_file_plan(
+    file_plan_cb: FilePlanCallback | None, filenames: list[str]
+) -> None:
+    if file_plan_cb and filenames:
+        file_plan_cb(list(filenames))
+
+
+def _emit_file_completed(
+    file_completed_cb: FileCompletedCallback | None,
+    filename: str,
+    local_path: str,
+) -> None:
+    if file_completed_cb:
+        file_completed_cb(filename, local_path)
+
+
+def _emit_json_ready(
+    json_ready_cb: JsonReadyCallback | None, split: str, json_path: str
+) -> None:
+    if json_ready_cb:
+        json_ready_cb(split, json_path)
 
 
 def _ensure_not_cancelled(is_cancelled: CancelCheck | None) -> None:
@@ -441,6 +467,9 @@ def _download_parquet_split_and_convert(
     token: str | None = None,
     progress_cb: ProgressCallback | None = None,
     byte_progress_cb: ByteProgressCallback | None = None,
+    file_plan_cb: FilePlanCallback | None = None,
+    file_completed_cb: FileCompletedCallback | None = None,
+    json_ready_cb: JsonReadyCallback | None = None,
     is_cancelled: CancelCheck | None = None,
 ) -> dict[str, Any]:
     cleaned_repo_id = str(repo_id or "").strip()
@@ -463,15 +492,20 @@ def _download_parquet_split_and_convert(
     tmp_dir = tempfile.mkdtemp(prefix="hf_parquet_dl_", dir=output_dir)
     try:
         if annotations_only:
+            metadata_filename = f"{cleaned_split}/metadata.parquet"
+            _emit_file_plan(file_plan_cb, [metadata_filename])
             metadata_path = _download_hf_file(
                 hf_hub_download,
                 repo_id=cleaned_repo_id,
-                filename=f"{cleaned_split}/metadata.parquet",
+                filename=metadata_filename,
                 revision=commit,
                 local_dir=tmp_dir,
                 token=token or None,
                 byte_progress_cb=byte_progress_cb,
                 is_cancelled=is_cancelled,
+            )
+            _emit_file_completed(
+                file_completed_cb, metadata_filename, metadata_path
             )
         else:
             if byte_progress_cb is None:
@@ -497,9 +531,14 @@ def _download_parquet_split_and_convert(
                     raise FileNotFoundError(
                         f"No files found for Parquet split: {cleaned_split}"
                     )
-                for remote_path in split_files:
+                _emit_file_plan(file_plan_cb, split_files)
+                for index, remote_path in enumerate(split_files, start=1):
                     _ensure_not_cancelled(is_cancelled)
-                    _download_hf_file(
+                    _emit_progress(
+                        progress_cb,
+                        f"[{index}/{len(split_files)}] Downloading {remote_path}",
+                    )
+                    downloaded_path = _download_hf_file(
                         hf_hub_download,
                         repo_id=cleaned_repo_id,
                         filename=remote_path,
@@ -508,6 +547,9 @@ def _download_parquet_split_and_convert(
                         token=token,
                         byte_progress_cb=byte_progress_cb,
                         is_cancelled=is_cancelled,
+                    )
+                    _emit_file_completed(
+                        file_completed_cb, remote_path, downloaded_path
                     )
         _ensure_not_cancelled(is_cancelled)
 
@@ -533,6 +575,9 @@ def _download_parquet_split_and_convert(
             split=cleaned_split,
             source_format="parquet",
             commit=commit,
+        )
+        _emit_json_ready(
+            json_ready_cb, cleaned_split, str(output_json_path)
         )
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
@@ -582,6 +627,9 @@ def _download_json_path_from_hf(
     token: str | None = None,
     progress_cb: ProgressCallback | None = None,
     byte_progress_cb: ByteProgressCallback | None = None,
+    file_plan_cb: FilePlanCallback | None = None,
+    file_completed_cb: FileCompletedCallback | None = None,
+    json_ready_cb: JsonReadyCallback | None = None,
     is_cancelled: CancelCheck | None = None,
 ) -> dict[str, Any]:
     HfApi, hf_hub_download, _ = _import_hf_hub()
@@ -593,6 +641,7 @@ def _download_json_path_from_hf(
     os.makedirs(output_dir, exist_ok=True)
     _ensure_not_cancelled(is_cancelled)
     _emit_progress(progress_cb, f"Downloading JSON from {repo_id}@{commit}: {path_in_repo}")
+    _emit_file_plan(file_plan_cb, [path_in_repo])
 
     json_path = _download_hf_file(
         hf_hub_download,
@@ -604,6 +653,7 @@ def _download_json_path_from_hf(
         byte_progress_cb=byte_progress_cb,
         is_cancelled=is_cancelled,
     )
+    _emit_file_completed(file_completed_cb, path_in_repo, json_path)
 
     _ensure_not_cancelled(is_cancelled)
     with open(json_path, "r", encoding="utf-8") as handle:
@@ -614,6 +664,7 @@ def _download_json_path_from_hf(
     except ValueError:
         repo_paths = []
     allow_patterns = _build_allow_patterns(repo_paths, repo_json_folder)
+    _emit_file_plan(file_plan_cb, allow_patterns)
 
     result: dict[str, Any] = {
         "repo_id": repo_id,
@@ -630,8 +681,11 @@ def _download_json_path_from_hf(
         "num_samples": len(osl_json.get("data", [])) if isinstance(osl_json.get("data"), list) else 0,
     }
 
-    if annotations_only:
-        _emit_progress(progress_cb, "Persisting Hugging Face source metadata into downloaded JSON.")
+    if not dry_run:
+        _emit_progress(
+            progress_cb,
+            "Persisting Hugging Face source metadata into downloaded JSON.",
+        )
         hf_source_metadata = write_hf_source_metadata_to_dataset_json(
             json_path,
             repo_id=repo_id,
@@ -640,9 +694,12 @@ def _download_json_path_from_hf(
             source_format="json",
             commit=commit,
         )
+        result["hf_source_metadata"] = hf_source_metadata
+        _emit_json_ready(json_ready_cb, cleaned_split, json_path)
+
+    if annotations_only:
         result["download_kind"] = "json"
         result["downloaded_file_count"] = 0
-        result["hf_source_metadata"] = hf_source_metadata
         _emit_progress(progress_cb, "Annotation-only download completed.")
         return result
 
@@ -701,7 +758,7 @@ def _download_json_path_from_hf(
     for idx, full_repo_path in enumerate(allow_patterns, start=1):
         _ensure_not_cancelled(is_cancelled)
         _emit_progress(progress_cb, f"[{idx}/{len(allow_patterns)}] Downloading {full_repo_path}")
-        _download_hf_file(
+        downloaded_path = _download_hf_file(
             hf_hub_download,
             repo_id=repo_id,
             filename=full_repo_path,
@@ -711,21 +768,13 @@ def _download_json_path_from_hf(
             byte_progress_cb=byte_progress_cb,
             is_cancelled=is_cancelled,
         )
+        _emit_file_completed(
+            file_completed_cb, full_repo_path, downloaded_path
+        )
         downloaded_count += 1
-
-    _emit_progress(progress_cb, "Persisting Hugging Face source metadata into downloaded JSON.")
-    hf_source_metadata = write_hf_source_metadata_to_dataset_json(
-        json_path,
-        repo_id=repo_id,
-        branch=revision,
-        split=cleaned_split,
-        source_format="json",
-        commit=commit,
-    )
 
     result["download_kind"] = "json"
     result["downloaded_file_count"] = downloaded_count
-    result["hf_source_metadata"] = hf_source_metadata
     _emit_progress(progress_cb, "Download completed.")
     return result
 
@@ -826,6 +875,9 @@ def download_dataset_splits_from_hf(
     token: str | None = None,
     progress_cb: ProgressCallback | None = None,
     byte_progress_cb: ByteProgressCallback | None = None,
+    file_plan_cb: FilePlanCallback | None = None,
+    file_completed_cb: FileCompletedCallback | None = None,
+    json_ready_cb: JsonReadyCallback | None = None,
     is_cancelled: CancelCheck | None = None,
 ) -> list[dict[str, Any]]:
     cleaned_splits = [str(split or "").strip() for split in (splits or [])]
@@ -852,6 +904,9 @@ def download_dataset_splits_from_hf(
             token=token,
             progress_cb=_scoped_progress,
             byte_progress_cb=byte_progress_cb,
+            file_plan_cb=file_plan_cb,
+            file_completed_cb=file_completed_cb,
+            json_ready_cb=json_ready_cb,
             is_cancelled=is_cancelled,
         )
         results.append(result)
@@ -871,6 +926,9 @@ def download_dataset_split_from_hf(
     token: str | None = None,
     progress_cb: ProgressCallback | None = None,
     byte_progress_cb: ByteProgressCallback | None = None,
+    file_plan_cb: FilePlanCallback | None = None,
+    file_completed_cb: FileCompletedCallback | None = None,
+    json_ready_cb: JsonReadyCallback | None = None,
     is_cancelled: CancelCheck | None = None,
 ) -> dict[str, Any]:
     cleaned_repo_id = str(repo_id or "").strip()
@@ -899,6 +957,9 @@ def download_dataset_split_from_hf(
             token=token,
             progress_cb=progress_cb,
             byte_progress_cb=byte_progress_cb,
+            file_plan_cb=file_plan_cb,
+            file_completed_cb=file_completed_cb,
+            json_ready_cb=json_ready_cb,
             is_cancelled=is_cancelled,
         )
 
@@ -913,6 +974,9 @@ def download_dataset_split_from_hf(
         token=token,
         progress_cb=progress_cb,
         byte_progress_cb=byte_progress_cb,
+        file_plan_cb=file_plan_cb,
+        file_completed_cb=file_completed_cb,
+        json_ready_cb=json_ready_cb,
         is_cancelled=is_cancelled,
     )
 

--- a/opensportslib/tools/hf_transfer.py
+++ b/opensportslib/tools/hf_transfer.py
@@ -664,7 +664,8 @@ def _download_json_path_from_hf(
     except ValueError:
         repo_paths = []
     allow_patterns = _build_allow_patterns(repo_paths, repo_json_folder)
-    _emit_file_plan(file_plan_cb, allow_patterns)
+    if not annotations_only:
+        _emit_file_plan(file_plan_cb, allow_patterns)
 
     result: dict[str, Any] = {
         "repo_id": repo_id,

--- a/opensportslib/tools/hf_transfer.py
+++ b/opensportslib/tools/hf_transfer.py
@@ -128,6 +128,23 @@ def _import_hf_file_system():
     return HfFileSystem, TqdmCallback
 
 
+def _import_hf_xet_download():
+    try:
+        from huggingface_hub import get_hf_file_metadata, hf_hub_url
+        from huggingface_hub.file_download import xet_get
+        from huggingface_hub.utils import build_hf_headers
+        from huggingface_hub.utils._runtime import is_xet_available
+    except ImportError:
+        return None
+    return (
+        get_hf_file_metadata,
+        hf_hub_url,
+        xet_get,
+        build_hf_headers,
+        is_xet_available,
+    )
+
+
 def _download_hf_file(
     hf_hub_download,
     *,
@@ -169,7 +186,6 @@ def _download_hf_file(
             token=token or None,
         )
 
-    HfFileSystem, TqdmCallback = _import_hf_file_system()
     destination.parent.mkdir(parents=True, exist_ok=True)
     file_descriptor, temporary_path = tempfile.mkstemp(
         prefix=f".{destination.name}.",
@@ -198,9 +214,43 @@ def _download_hf_file(
         def close(self):
             pass
 
-    callback = TqdmCallback(tqdm_cls=_CallbackProgress)
     remote_path = f"datasets/{repo_id}/{normalized_filename}"
     try:
+        xet_download = _import_hf_xet_download()
+        if xet_download is not None:
+            (
+                get_hf_file_metadata,
+                hf_hub_url,
+                xet_get,
+                build_hf_headers,
+                is_xet_available,
+            ) = xet_download
+            if is_xet_available():
+                metadata = get_hf_file_metadata(
+                    hf_hub_url(
+                        repo_id=repo_id,
+                        repo_type="dataset",
+                        filename=normalized_filename,
+                        revision=revision,
+                    ),
+                    token=token or None,
+                )
+                if metadata.xet_file_data is not None:
+                    progress = _CallbackProgress(total=metadata.size)
+                    xet_get(
+                        incomplete_path=Path(temporary_path),
+                        xet_file_data=metadata.xet_file_data,
+                        headers=build_hf_headers(token=token or None),
+                        expected_size=metadata.size,
+                        displayed_filename=normalized_filename,
+                        _tqdm_bar=progress,
+                    )
+                    _ensure_not_cancelled(is_cancelled)
+                    os.replace(temporary_path, destination)
+                    return str(destination)
+
+        HfFileSystem, TqdmCallback = _import_hf_file_system()
+        callback = TqdmCallback(tqdm_cls=_CallbackProgress)
         with callback:
             HfFileSystem(token=token or None).get_file(
                 remote_path,

--- a/tests/test_hf_transfer_tools.py
+++ b/tests/test_hf_transfer_tools.py
@@ -1111,6 +1111,9 @@ def test_download_dataset_split_from_hf_json_downloads_split_json_and_all_inputs
         ]
     }
     downloaded = []
+    planned = []
+    completed = []
+    json_ready = []
 
     class _FakeApi:
         def __init__(self, token=None):
@@ -1140,6 +1143,11 @@ def test_download_dataset_split_from_hf_json_downloads_split_json_and_all_inputs
         "test",
         str(tmp_path),
         download_format="json",
+        file_plan_cb=planned.append,
+        file_completed_cb=lambda filename, path: completed.append(
+            (filename, path)
+        ),
+        json_ready_cb=lambda split, path: json_ready.append((split, path)),
     )
 
     assert downloaded == ["test.json", "test/captions.json", "test/clip_0.mp4"]
@@ -1152,6 +1160,12 @@ def test_download_dataset_split_from_hf_json_downloads_split_json_and_all_inputs
     assert result["output_dir"] == str(expected_output_dir)
     assert result["json_path"] == str(expected_output_dir / "test.json")
     assert result["downloaded_file_count"] == 2
+    assert planned == [
+        ["test.json"],
+        ["test/captions.json", "test/clip_0.mp4"],
+    ]
+    assert [filename for filename, _path in completed] == downloaded
+    assert json_ready == [("test", str(expected_output_dir / "test.json"))]
 
 
 def test_download_dataset_split_from_hf_parquet_downloads_split_folder(monkeypatch, tmp_path):
@@ -1196,6 +1210,78 @@ def test_download_dataset_split_from_hf_parquet_downloads_split_folder(monkeypat
     assert result["json_path"] == str(tmp_path / "dev" / "test" / "test.json")
     assert result["num_samples"] == 3
     assert result["download_skipped"] is False
+
+
+def test_parquet_byte_download_reports_file_count_progress(monkeypatch, tmp_path):
+    progress_messages = []
+    downloaded = []
+    planned = []
+    completed = []
+    json_ready = []
+
+    class _FakeApi:
+        def __init__(self, token=None):
+            pass
+
+        def repo_info(self, **kwargs):
+            return type("_Info", (), {"sha": "pinned"})()
+
+        def list_repo_files(self, *args, **kwargs):
+            return [
+                "test/metadata.parquet",
+                "test/shards/shard-000000.tar",
+            ]
+
+    def _fake_download_file(_hf_hub_download, **kwargs):
+        downloaded.append(kwargs["filename"])
+        return str(Path(kwargs["local_dir"]) / kwargs["filename"])
+
+    def _fake_conversion(**kwargs):
+        kwargs["output_json_path"].write_text(
+            json.dumps({"data": []}), encoding="utf-8"
+        )
+        return {"num_samples": 0, "extracted_media_files": 0}
+
+    monkeypatch.setattr(
+        "opensportslib.tools.hf_transfer._import_hf_hub",
+        lambda: (_FakeApi, object(), object()),
+    )
+    monkeypatch.setattr(
+        "opensportslib.tools.hf_transfer._download_hf_file",
+        _fake_download_file,
+    )
+    monkeypatch.setattr(
+        "opensportslib.tools.hf_transfer.convert_parquet_to_json",
+        _fake_conversion,
+    )
+
+    download_dataset_split_from_hf(
+        "OpenSportsLab/repo",
+        "main",
+        "test",
+        str(tmp_path),
+        download_format="parquet",
+        progress_cb=progress_messages.append,
+        byte_progress_cb=lambda *_args: None,
+        file_plan_cb=planned.append,
+        file_completed_cb=lambda filename, path: completed.append(
+            (filename, path)
+        ),
+        json_ready_cb=lambda split, path: json_ready.append((split, path)),
+    )
+
+    assert downloaded == [
+        "test/metadata.parquet",
+        "test/shards/shard-000000.tar",
+    ]
+    assert "[1/2] Downloading test/metadata.parquet" in progress_messages
+    assert "[2/2] Downloading test/shards/shard-000000.tar" in progress_messages
+    assert planned == [[
+        "test/metadata.parquet",
+        "test/shards/shard-000000.tar",
+    ]]
+    assert [filename for filename, _path in completed] == downloaded
+    assert json_ready == [("test", str(tmp_path / "main" / "test" / "test.json"))]
 
 
 def test_download_dataset_split_from_hf_parquet_completes_existing_json(

--- a/tests/test_hf_transfer_tools.py
+++ b/tests/test_hf_transfer_tools.py
@@ -70,6 +70,7 @@ def test_download_hf_file_reports_transferred_and_total_bytes(monkeypatch, tmp_p
         "_import_hf_file_system",
         lambda: (_FakeFileSystem, TqdmCallback),
     )
+    monkeypatch.setattr(hf_transfer_module, "_import_hf_xet_download", lambda: None)
     progress = []
 
     result = hf_transfer_module._download_hf_file(
@@ -115,6 +116,7 @@ def test_download_hf_file_cancels_during_transfer_and_removes_partial(
         "_import_hf_file_system",
         lambda: (_FakeFileSystem, TqdmCallback),
     )
+    monkeypatch.setattr(hf_transfer_module, "_import_hf_xet_download", lambda: None)
 
     with pytest.raises(HfTransferCancelled):
         hf_transfer_module._download_hf_file(
@@ -130,6 +132,62 @@ def test_download_hf_file_cancels_during_transfer_and_removes_partial(
 
     assert not (tmp_path / "clips" / "large.mp4").exists()
     assert list((tmp_path / "clips").glob("*.part")) == []
+
+
+def test_download_hf_file_reports_bytes_while_using_xet(monkeypatch, tmp_path):
+    xet_file_data = object()
+
+    class _Metadata:
+        size = 6
+
+    _Metadata.xet_file_data = xet_file_data
+
+    def _fake_xet_get(**kwargs):
+        assert kwargs["xet_file_data"] is xet_file_data
+        assert kwargs["headers"] == {"authorization": "Bearer hf_test"}
+        assert kwargs["expected_size"] == 6
+        assert kwargs["displayed_filename"] == "clips/large.mp4"
+        Path(kwargs["incomplete_path"]).write_bytes(b"abcdef")
+        kwargs["_tqdm_bar"].update(2)
+        kwargs["_tqdm_bar"].update(4)
+
+    monkeypatch.setattr(
+        hf_transfer_module,
+        "_import_hf_xet_download",
+        lambda: (
+            lambda url, token: _Metadata(),
+            lambda **kwargs: "https://huggingface.test/file",
+            _fake_xet_get,
+            lambda token: {"authorization": f"Bearer {token}"},
+            lambda: True,
+        ),
+    )
+    monkeypatch.setattr(
+        hf_transfer_module,
+        "_import_hf_file_system",
+        lambda: pytest.fail("classic HTTP fallback should not be used"),
+    )
+    progress = []
+
+    result = hf_transfer_module._download_hf_file(
+        pytest.fail,
+        repo_id="OpenSportsLab/repo",
+        filename="clips/large.mp4",
+        revision="pinned",
+        local_dir=str(tmp_path),
+        token="hf_test",
+        byte_progress_cb=lambda filename, current, total: progress.append(
+            (filename, current, total)
+        ),
+    )
+
+    assert result == str(tmp_path / "clips" / "large.mp4")
+    assert Path(result).read_bytes() == b"abcdef"
+    assert progress == [
+        ("clips/large.mp4", 0, 6),
+        ("clips/large.mp4", 2, 6),
+        ("clips/large.mp4", 6, 6),
+    ]
 
 
 def test_download_hf_file_rejects_unsafe_destination(tmp_path):

--- a/tests/test_hf_transfer_tools.py
+++ b/tests/test_hf_transfer_tools.py
@@ -1340,6 +1340,7 @@ def test_json_annotations_only_downloads_json_and_persists_pinned_source(monkeyp
         encoding="utf-8",
     )
     downloaded = []
+    planned = []
 
     class _FakeApi:
         def __init__(self, token=None):
@@ -1359,9 +1360,11 @@ def test_json_annotations_only_downloads_json_and_persists_pinned_source(monkeyp
         str(tmp_path / "output"),
         download_format="json",
         annotations_only=True,
+        file_plan_cb=planned.append,
     )
 
     assert downloaded == ["test.json"]
+    assert planned == [["test.json"]]
     payload = json.loads(Path(result["json_path"]).read_text(encoding="utf-8"))
     assert payload[HF_FORMAT_KEY] == "json"
     assert payload[HF_COMMIT_KEY] == "pinned-json"


### PR DESCRIPTION
## Summary
- preserve accelerated Xet transfers when byte progress callbacks are enabled
- adapt Xet byte updates to the existing progress callback contract
- retain the classic HTTP fallback when Xet is unavailable, disabled, or unused
- document the behavior and add focused regression coverage

## Testing
- `tests/test_hf_transfer_tools.py`: 48 passed as part of the full suite
- `pytest tests/test_*.py`: 300 passed, 5 skipped, 13 failed

The 13 failures are outside the files changed by this branch and cover existing config expectations, localization test fixtures, missing optional NVIDIA modules, and ARM-specific setup expectations.